### PR TITLE
Implement MarshalJSON for object types; update server

### DIFF
--- a/cmd/risor-api/main.go
+++ b/cmd/risor-api/main.go
@@ -11,22 +11,21 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/risor-io/risor"
-	"github.com/risor-io/risor/modules/all"
-	"github.com/risor-io/risor/parser"
+	"github.com/risor-io/risor/errz"
 )
 
 type Request struct {
-	Content string `json:"content"`
+	Code string `json:"code"`
 }
 
 type Response struct {
-	Result string `json:"result"`
-	Time   float64 `json:"time"`
+	Result json.RawMessage `json:"result"`
+	Time   float64         `json:"time"`
 }
 
 func main() {
 	var port string
-	flag.StringVar(&port, "port", "3000", "Define port for the server to listen on")
+	flag.StringVar(&port, "port", "8000", "Define port for the server to listen on")
 	flag.Parse()
 
 	r := chi.NewRouter()
@@ -36,48 +35,55 @@ func main() {
 	})
 
 	log.Println("Server started on http://localhost:" + port)
-	log.Fatal(http.ListenAndServe(":" + port, r))
+	log.Fatal(http.ListenAndServe(":"+port, r))
 }
 
 func executeHandler(w http.ResponseWriter, r *http.Request) {
 	var req Request
 	var res Response
-	json.NewDecoder(r.Body).Decode(&req)
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Expected a JSON body in the request", http.StatusBadRequest)
+		return
+	}
 
-	input := req.Content
-	if input == "" {
+	if req.Code == "" {
 		http.Error(w, "Please provide a code snippet", http.StatusBadRequest)
 		return
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
 	start := time.Now()
 
-	result, err := risor.Eval(ctx, string(input),
-		risor.WithBuiltins(all.Builtins()),
+	result, err := risor.Eval(ctx,
+		string(req.Code),
 		risor.WithDefaultBuiltins(),
 		risor.WithDefaultModules())
 	if err != nil {
-		parserErr, ok := err.(parser.ParserError)
-		if ok {
-			http.Error(w, parserErr.FriendlyMessage(), http.StatusInternalServerError)
+		if friendlyErr, ok := err.(errz.FriendlyError); ok {
+			http.Error(w, friendlyErr.FriendlyErrorMessage(), http.StatusBadRequest)
 		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			http.Error(w, err.Error(), http.StatusBadRequest)
 		}
 		return
 	}
 
-	res.Result = result.Inspect()
+	res.Result, err = json.Marshal(result)
+	if err != nil {
+		http.Error(w, "Unable to marshal output", http.StatusInternalServerError)
+		return
+	}
 
 	res.Time = time.Since(start).Seconds()
 
 	response, err := json.Marshal(res)
 	if err != nil {
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		http.Error(w, "Unable to marshal output", http.StatusInternalServerError)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
+	w.WriteHeader(http.StatusOK)
 	w.Write(response)
 }

--- a/cmd/risor-api/main_test.go
+++ b/cmd/risor-api/main_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestExecuteHandler(t *testing.T) {
 	payload := Request{
-		Content: "['welcome', 'to', 'risor', '👋'] | strings.join(' ')",
+		Code: "['welcome', 'to', 'risor', '👋'] | strings.join(' ')",
 	}
 	payloadBytes, _ := json.Marshal(payload)
 
@@ -23,7 +23,7 @@ func TestExecuteHandler(t *testing.T) {
 
 	executeHandler(rr, req)
 
-	if status := rr.Code; status != http.StatusCreated {
+	if status := rr.Code; status != http.StatusOK {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusCreated)
 	}
 
@@ -32,8 +32,8 @@ func TestExecuteHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedResult :=  "\"welcome to risor 👋\""
-	if response.Result != expectedResult {
+	expectedResult := "\"welcome to risor 👋\""
+	if string(response.Result) != expectedResult {
 		t.Errorf("handler returned unexpected result: got %s want %s", response.Result, expectedResult)
 	}
 

--- a/cmd/risor/main.go
+++ b/cmd/risor/main.go
@@ -88,7 +88,7 @@ func main() {
 	if err != nil {
 		parserErr, ok := err.(parser.ParserError)
 		if ok {
-			fmt.Fprintf(os.Stderr, "%s\n", red(parserErr.FriendlyMessage()))
+			fmt.Fprintf(os.Stderr, "%s\n", red(parserErr.FriendlyErrorMessage()))
 		} else {
 			fmt.Fprintf(os.Stderr, "%s\n", red(err.Error()))
 		}

--- a/errz/errz.go
+++ b/errz/errz.go
@@ -1,0 +1,8 @@
+package errz
+
+// FriendlyError is an interface for errors that have a human friendly message
+// in addition to a the lower level default error message.
+type FriendlyError interface {
+	Error() string
+	FriendlyErrorMessage() string
+}

--- a/modules/aws/client.go
+++ b/modules/aws/client.go
@@ -74,6 +74,10 @@ func (c *Client) Cost() int {
 	return 0
 }
 
+func (c *Client) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("type error: unable to marshal aws.client")
+}
+
 func NewClient(service string, client interface{}) *Client {
 	return &Client{service: service, client: client, methods: loadMethods(client)}
 }

--- a/modules/aws/config.go
+++ b/modules/aws/config.go
@@ -198,6 +198,10 @@ func (c *Config) Cost() int {
 	return 0
 }
 
+func (c *Config) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("type error: unable to marshal aws.config")
+}
+
 func NewConfig(cfg aws.Config) *Config {
 	return &Config{cfg: cfg}
 }

--- a/modules/image/image_object.go
+++ b/modules/image/image_object.go
@@ -155,6 +155,10 @@ func (img *Image) Cost() int {
 	return width * height * 24
 }
 
+func (img *Image) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("type error: unable to marshal image")
+}
+
 func NewImage(image image.Image, format string) *Image {
 	return &Image{image: image, format: format}
 }

--- a/modules/pgx/pgx_conn.go
+++ b/modules/pgx/pgx_conn.go
@@ -2,6 +2,7 @@ package pgx
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -93,6 +94,10 @@ func (c *PgxConn) waitToClose() {
 
 func (c *PgxConn) Cost() int {
 	return 8
+}
+
+func (c *PgxConn) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("type error: unable to marshal pgx.conn")
 }
 
 func New(ctx context.Context, conn *pgx.Conn) *PgxConn {

--- a/object/bool.go
+++ b/object/bool.go
@@ -72,6 +72,13 @@ func (b *Bool) RunOperation(opType op.BinaryOpType, right Object) Object {
 	return NewError(fmt.Errorf("eval error: unsupported operation for bool: %v", opType))
 }
 
+func (b *Bool) MarshalJSON() ([]byte, error) {
+	if b.value {
+		return []byte("true"), nil
+	}
+	return []byte("false"), nil
+}
+
 func NewBool(value bool) *Bool {
 	if value {
 		return True

--- a/object/buffer.go
+++ b/object/buffer.go
@@ -117,6 +117,10 @@ func (b *Buffer) Cost() int {
 	return len(b.value.Bytes())
 }
 
+func (b *Buffer) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("\"%s\"", b.value.String())), nil
+}
+
 func NewBuffer(buf *bytes.Buffer) *Buffer {
 	return &Buffer{value: buf}
 }

--- a/object/builtin.go
+++ b/object/builtin.go
@@ -101,6 +101,10 @@ func (b *Builtin) RunOperation(opType op.BinaryOpType, right Object) Object {
 	return NewError(fmt.Errorf("eval error: unsupported operation for builtin: %v", opType))
 }
 
+func (b *Builtin) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("type error: unable to marshal builtin")
+}
+
 // NewNoopBuiltin creates a builtin function that has no effect.
 func NewNoopBuiltin(name string, module *Module) *Builtin {
 	b := &Builtin{

--- a/object/byte.go
+++ b/object/byte.go
@@ -135,6 +135,10 @@ func (b *Byte) runOperationInt(opType op.BinaryOpType, right int64) Object {
 	}
 }
 
+func (b *Byte) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("%d", b.value)), nil
+}
+
 func NewByte(value byte) *Byte {
 	return &Byte{value: value}
 }

--- a/object/byte_slice.go
+++ b/object/byte_slice.go
@@ -3,6 +3,7 @@ package object
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/risor-io/risor/op"
@@ -471,6 +472,10 @@ func (b *ByteSlice) ReplaceAll(old, new Object) Object {
 
 func (b *ByteSlice) Cost() int {
 	return len(b.value)
+}
+
+func (b *ByteSlice) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(b.value))
 }
 
 func NewByteSlice(value []byte) *ByteSlice {

--- a/object/cell.go
+++ b/object/cell.go
@@ -55,6 +55,10 @@ func (c *Cell) RunOperation(opType op.BinaryOpType, right Object) Object {
 	return NewError(fmt.Errorf("eval error: unsupported operation for cell: %v", opType))
 }
 
+func (c *Cell) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("type error: unable to marshal cell")
+}
+
 func NewCell(value *Object) *Cell {
 	return &Cell{value: value}
 }

--- a/object/code_proxy.go
+++ b/object/code_proxy.go
@@ -62,6 +62,10 @@ func (c *CodeProxy) RunOperation(opType op.BinaryOpType, right Object) Object {
 	return NewError(fmt.Errorf("eval error: unsupported operation for code: %v", opType))
 }
 
+func (c *CodeProxy) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("type error: unable to marshal code")
+}
+
 func NewCodeProxy(c *Code) *CodeProxy {
 
 	// Provide some isolation

--- a/object/color.go
+++ b/object/color.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"image/color"
@@ -72,6 +73,16 @@ func (c *Color) Equals(other Object) Object {
 
 func (c *Color) RunOperation(opType op.BinaryOpType, right Object) Object {
 	return NewError(fmt.Errorf("eval error: unsupported operation for color: %v ", opType))
+}
+
+func (c *Color) MarshalJSON() ([]byte, error) {
+	r, g, b, a := c.c.RGBA()
+	return json.Marshal(map[string]interface{}{
+		"r": r,
+		"g": g,
+		"b": b,
+		"a": a,
+	})
 }
 
 func NewColor(c color.Color) *Color {

--- a/object/error.go
+++ b/object/error.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/risor-io/risor/op"
@@ -79,6 +80,10 @@ func Errorf(format string, a ...interface{}) *Error {
 		}
 	}
 	return &Error{err: fmt.Errorf(format, args...)}
+}
+
+func (e *Error) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("type error: unable to marshal error")
 }
 
 func NewError(err error) *Error {

--- a/object/file.go
+++ b/object/file.go
@@ -188,6 +188,10 @@ func (f *File) Cost() int {
 	return 8
 }
 
+func (f *File) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("type error: unable to marshal file")
+}
+
 func NewFile(ctx context.Context, value tos.File, path string) *File {
 	f := &File{
 		ctx:    ctx,

--- a/object/file_test.go
+++ b/object/file_test.go
@@ -1,0 +1,19 @@
+package object_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/risor-io/risor/object"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalFile(t *testing.T) {
+	ctx := context.Background()
+	f := object.NewFile(ctx, nil, "")
+	bytes, err := json.Marshal(f)
+	require.Nil(t, bytes)
+	require.NotNil(t, err)
+	require.Equal(t, "json: error calling MarshalJSON for type *object.File: type error: unable to marshal file", err.Error())
+}

--- a/object/float.go
+++ b/object/float.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"strconv"
@@ -106,6 +107,10 @@ func (f *Float) runOperationFloat(opType op.BinaryOpType, right float64) Object 
 	default:
 		return NewError(fmt.Errorf("eval error: unsupported operation for float: %v", opType))
 	}
+}
+
+func (f *Float) MarshalJSON() ([]byte, error) {
+	return json.Marshal(f.value)
 }
 
 func NewFloat(value float64) *Float {

--- a/object/float_slice.go
+++ b/object/float_slice.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/risor-io/risor/op"
@@ -137,6 +138,10 @@ func (f *FloatSlice) Integers() []Object {
 
 func (f *FloatSlice) Cost() int {
 	return len(f.value)
+}
+
+func (f *FloatSlice) MarshalJSON() ([]byte, error) {
+	return json.Marshal(f.value)
 }
 
 func NewFloatSlice(value []float64) *FloatSlice {

--- a/object/function.go
+++ b/object/function.go
@@ -107,6 +107,10 @@ func (f *Function) LocalsCount() int {
 	return int(f.code.Symbols.Size())
 }
 
+func (f *Function) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("type error: unable to marshal function")
+}
+
 type FunctionOpts struct {
 	Name           string
 	ParameterNames []string

--- a/object/go_field.go
+++ b/object/go_field.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 
@@ -74,6 +75,14 @@ func (f *GoField) RunOperation(opType op.BinaryOpType, right Object) Object {
 
 func (f *GoField) Converter() (TypeConverter, bool) {
 	return f.converter, f.converter != nil
+}
+
+func (f *GoField) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]interface{}{
+		"name": f.name,
+		"type": f.fieldType,
+		"tag":  f.tag,
+	})
 }
 
 func newGoField(f reflect.StructField) (*GoField, error) {

--- a/object/go_method.go
+++ b/object/go_method.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 
@@ -134,6 +135,14 @@ func (m *GoMethod) ErrorIndices() []int {
 
 func (m *GoMethod) IsOutputError(index int) bool {
 	return m.outputIsError[index]
+}
+
+func (m *GoMethod) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]interface{}{
+		"name":    m.name.value,
+		"num_in":  m.numIn.value,
+		"num_out": m.numOut.value,
+	})
 }
 
 // Returns a Risor *GoMethod Object that represents the given Go method.

--- a/object/http_response.go
+++ b/object/http_response.go
@@ -160,6 +160,10 @@ func (r *HttpResponse) Cost() int {
 	return 8 + int(r.resp.ContentLength)
 }
 
+func (r *HttpResponse) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("type error: unable to marshal http.response")
+}
+
 func NewHttpResponse(
 	resp *http.Response,
 	timeout time.Duration,

--- a/object/int.go
+++ b/object/int.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 
@@ -135,6 +136,10 @@ func (i *Int) runOperationFloat(opType op.BinaryOpType, right float64) Object {
 	default:
 		return NewError(fmt.Errorf("eval error: unsupported operation for int: %v on type float", opType))
 	}
+}
+
+func (i *Int) MarshalJSON() ([]byte, error) {
+	return json.Marshal(i.value)
 }
 
 func NewInt(value int64) *Int {

--- a/object/iter_entry.go
+++ b/object/iter_entry.go
@@ -82,6 +82,10 @@ func (e *Entry) WithValueAsPrimary() *Entry {
 	return e
 }
 
+func (e *Entry) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("type error: unable to marshal entry")
+}
+
 func NewEntry(key, value Object) *Entry {
 	return &Entry{key: key, value: value}
 }

--- a/object/list.go
+++ b/object/list.go
@@ -3,6 +3,7 @@ package object
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -598,6 +599,10 @@ func (ls *List) Cost() int {
 	// It would be possible to recurse into the list and compute the cost of
 	// each item, but let's avoid that since it would be an expensive op itself.
 	return len(ls.items) * 8
+}
+
+func (ls *List) MarshalJSON() ([]byte, error) {
+	return json.Marshal(ls.items)
 }
 
 func NewList(items []Object) *List {

--- a/object/list_iter.go
+++ b/object/list_iter.go
@@ -107,6 +107,10 @@ func (iter *ListIter) Entry() (IteratorEntry, bool) {
 	return NewEntry(NewInt(iter.pos), iter.current), true
 }
 
+func (iter *ListIter) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("type error: unable to marshal list_iter")
+}
+
 func NewListIter(l *List) *ListIter {
 	return &ListIter{l: l, pos: -1}
 }

--- a/object/map.go
+++ b/object/map.go
@@ -3,6 +3,7 @@ package object
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -407,6 +408,10 @@ func (m *Map) Cost() int {
 	// It would be possible to recurse and compute the cost of each item, but
 	// let's avoid that since it would be an expensive op itself.
 	return len(m.items) * 8
+}
+
+func (m *Map) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.items)
 }
 
 func NewMap(m map[string]Object) *Map {

--- a/object/map_iter.go
+++ b/object/map_iter.go
@@ -113,6 +113,10 @@ func (iter *MapIter) Entry() (IteratorEntry, bool) {
 	return NewEntry(iter.current, value).WithKeyAsPrimary(), true
 }
 
+func (iter *MapIter) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("type error: unable to marshal map_iter")
+}
+
 func NewMapIter(m *Map) *MapIter {
 	return &MapIter{m: m, keys: m.SortedKeys(), pos: -1}
 }

--- a/object/module.go
+++ b/object/module.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/risor-io/risor/op"
@@ -84,6 +85,10 @@ func (m *Module) Equals(other Object) Object {
 		return True
 	}
 	return False
+}
+
+func (m *Module) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("type error: unable to marshal module")
 }
 
 func NewModule(name string, code *Code) *Module {

--- a/object/nil.go
+++ b/object/nil.go
@@ -45,6 +45,10 @@ func (n *NilType) IsTruthy() bool {
 	return false
 }
 
+func (n *NilType) MarshalJSON() ([]byte, error) {
+	return []byte("null"), nil
+}
+
 func (n *NilType) RunOperation(opType op.BinaryOpType, right Object) Object {
 	return NewError(fmt.Errorf("eval error: unsupported operation for nil: %v", opType))
 }

--- a/object/partial.go
+++ b/object/partial.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -47,6 +48,10 @@ func (p *Partial) Equals(other Object) Object {
 
 func (p *Partial) RunOperation(opType op.BinaryOpType, right Object) Object {
 	return NewError(fmt.Errorf("eval error: unsupported operation for nil: %v", opType))
+}
+
+func (p *Partial) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("type error: unable to marshal partial")
 }
 
 func NewPartial(fn Object, args []Object) *Partial {

--- a/object/proxy.go
+++ b/object/proxy.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"sync"
@@ -215,6 +216,10 @@ func (p *Proxy) call(ctx context.Context, m *GoMethod, args ...Object) Object {
 		}
 	}
 	return NewList(results)
+}
+
+func (p *Proxy) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.obj)
 }
 
 // NewProxy returns a new Risor proxy object that wraps the given Go object.

--- a/object/set.go
+++ b/object/set.go
@@ -3,6 +3,7 @@ package object
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -285,6 +286,10 @@ func (s *Set) Keys() []HashKey {
 
 func (s *Set) Cost() int {
 	return len(s.items) * 8
+}
+
+func (s *Set) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.SortedItems())
 }
 
 func NewSet(items []Object) Object {

--- a/object/set_iter.go
+++ b/object/set_iter.go
@@ -114,6 +114,10 @@ func (iter *SetIter) Entry() (IteratorEntry, bool) {
 	return NewEntry(iter.current, True).WithKeyAsPrimary(), true
 }
 
+func (iter *SetIter) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("type error: unable to marshal set_iter")
+}
+
 func NewSetIter(set *Set) *SetIter {
 	return &SetIter{set: set, keys: set.Keys(), pos: -1}
 }

--- a/object/slice_iter.go
+++ b/object/slice_iter.go
@@ -113,6 +113,10 @@ func (iter *SliceIter) RunOperation(opType op.BinaryOpType, right Object) Object
 	return NewError(fmt.Errorf("eval error: unsupported operation for slice_iter: %v", opType))
 }
 
+func (iter *SliceIter) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("type error: unable to marshal slice_iter")
+}
+
 func NewSliceIter(s interface{}) (*SliceIter, error) {
 	typ := reflect.TypeOf(s)
 	if typ.Kind() != reflect.Slice {

--- a/object/string.go
+++ b/object/string.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -443,6 +444,10 @@ func (s *String) Runes() []Object {
 
 func (s *String) Cost() int {
 	return len(s.value)
+}
+
+func (s *String) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.value)
 }
 
 func NewString(s string) *String {

--- a/object/time.go
+++ b/object/time.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -129,4 +130,8 @@ func (t *Time) Unix(ctx context.Context, args ...Object) Object {
 
 func (t *Time) IsTruthy() bool {
 	return !t.value.IsZero()
+}
+
+func (t *Time) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.value.Format(time.RFC3339))
 }

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/risor-io/risor/errz"
 	"github.com/risor-io/risor/token"
 )
 
@@ -45,7 +46,7 @@ type ParserError interface {
 	EndPosition() token.Position
 	SourceCode() string
 	Error() string
-	FriendlyMessage() string
+	errz.FriendlyError
 }
 
 // BaseParserError is the simplest implementation of ParserError.
@@ -79,7 +80,7 @@ func (e *BaseParserError) Error() string {
 	return msg
 }
 
-func (e *BaseParserError) FriendlyMessage() string {
+func (e *BaseParserError) FriendlyErrorMessage() string {
 	var msg bytes.Buffer
 	header := e.Error()
 	msg.WriteString(header)

--- a/risor.go
+++ b/risor.go
@@ -8,11 +8,14 @@ import (
 	"github.com/risor-io/risor/importer"
 	modBase64 "github.com/risor-io/risor/modules/base64"
 	modBytes "github.com/risor-io/risor/modules/bytes"
+	modHash "github.com/risor-io/risor/modules/hash"
 	modJson "github.com/risor-io/risor/modules/json"
 	modMath "github.com/risor-io/risor/modules/math"
 	modRand "github.com/risor-io/risor/modules/rand"
 	modStrconv "github.com/risor-io/risor/modules/strconv"
 	modStrings "github.com/risor-io/risor/modules/strings"
+	modTime "github.com/risor-io/risor/modules/time"
+	modUuid "github.com/risor-io/risor/modules/uuid"
 	"github.com/risor-io/risor/object"
 	"github.com/risor-io/risor/parser"
 	"github.com/risor-io/risor/vm"
@@ -133,13 +136,19 @@ func Eval(ctx context.Context, source string, options ...Option) (object.Object,
 }
 
 func defaultModules() map[string]object.Object {
-	return map[string]object.Object{
+	result := map[string]object.Object{
 		"math":    modMath.Module(),
 		"json":    modJson.Module(),
 		"strings": modStrings.Module(),
+		"time":    modTime.Module(),
 		"rand":    modRand.Module(),
 		"strconv": modStrconv.Module(),
+		"uuid":    modUuid.Module(),
 		"bytes":   modBytes.Module(),
 		"base64":  modBase64.Module(),
 	}
+	for k, v := range modHash.Builtins() {
+		result[k] = v
+	}
+	return result
 }

--- a/tests/eval_test.go
+++ b/tests/eval_test.go
@@ -137,7 +137,7 @@ func TestFiles(t *testing.T) {
 				parserErr, ok := err.(parser.ParserError)
 				require.True(t, ok)
 				fmt.Println("--- Friendly error output for", name)
-				fmt.Println(parserErr.FriendlyMessage())
+				fmt.Println(parserErr.FriendlyErrorMessage())
 				fmt.Println("---")
 				require.Equal(t,
 					tc.ExpectedErrColumn,
@@ -149,7 +149,7 @@ func TestFiles(t *testing.T) {
 				parserErr, ok := err.(parser.ParserError)
 				require.True(t, ok)
 				fmt.Println("--- Friendly error output for", name)
-				fmt.Println(parserErr.FriendlyMessage())
+				fmt.Println(parserErr.FriendlyErrorMessage())
 				fmt.Println("---")
 				require.Equal(t,
 					tc.ExpectedErrLine,


### PR DESCRIPTION
Implementing MarshalJSON for object types means we can more easily marshal the results of script executions.