### PR TITLE
Minor adjustments to allow scripts to accept args/opts

### DIFF
--- a/cmd/risor/root.go
+++ b/cmd/risor/root.go
@@ -44,9 +44,6 @@ func init() {
 	rootCmd.PersistentFlags().Bool("no-default-builtins", false, "Disable the default builtins")
 	rootCmd.PersistentFlags().BoolP("help", "h", false, "Help for Risor")
 
-	rootCmd.Flags().Bool("timing", false, "Show timing information")
-	rootCmd.Flags().StringP("output", "o", "", "Set the output format")
-
 	viper.BindPFlag("code", rootCmd.PersistentFlags().Lookup("code"))
 	viper.BindPFlag("stdin", rootCmd.PersistentFlags().Lookup("stdin"))
 	viper.BindPFlag("cpu-profile", rootCmd.PersistentFlags().Lookup("cpu-profile"))
@@ -58,6 +55,9 @@ func init() {
 	viper.BindPFlag("no-default-modules", rootCmd.PersistentFlags().Lookup("no-default-modules"))
 	viper.BindPFlag("no-default-builtins", rootCmd.PersistentFlags().Lookup("no-default-builtins"))
 	viper.BindPFlag("help", rootCmd.PersistentFlags().Lookup("help"))
+
+	rootCmd.Flags().Bool("timing", false, "Show timing information")
+	rootCmd.Flags().StringP("output", "o", "", "Set the output format")
 
 	viper.AutomaticEnv()
 }
@@ -103,7 +103,7 @@ var rootCmd = &cobra.Command{
 	Use:   "risor",
 	Short: "Risor helps developers work with the cloud",
 	Long:  `https://risor.io`,
-	Args:  cobra.MaximumNArgs(1), // optional code filepath
+	Args:  cobra.ArbitraryArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		ctx := context.Background()

--- a/examples/scripts/closure.tm
+++ b/examples/scripts/closure.tm
@@ -1,4 +1,4 @@
-#!/usr/bin/env risor
+#!/usr/bin/env risor --
 
 func incrementer(value=0) {
     func inner() {

--- a/examples/scripts/helloworld.tm
+++ b/examples/scripts/helloworld.tm
@@ -1,3 +1,3 @@
-#!/usr/bin/env risor
+#!/usr/bin/env risor --
 
 print("Hello world!")

--- a/examples/scripts/invoke-lambda.tm
+++ b/examples/scripts/invoke-lambda.tm
@@ -1,3 +1,4 @@
+#!/usr/bin/env risor --
 
 client := aws.client('lambda')
 client.invoke({FunctionName: 'example1'})['Payload'] | decode('base64') | json.unmarshal

--- a/examples/scripts/loop.tm
+++ b/examples/scripts/loop.tm
@@ -1,4 +1,4 @@
-#!/usr/bin/env risor
+#!/usr/bin/env risor --
 
 d := {
     one: 1, 

--- a/examples/scripts/math.tm
+++ b/examples/scripts/math.tm
@@ -1,4 +1,4 @@
-#!/usr/bin/env risor
+#!/usr/bin/env risor --
 
 func square(n) { n * n }
 

--- a/examples/scripts/pgx.tm
+++ b/examples/scripts/pgx.tm
@@ -1,4 +1,4 @@
-#!/usr/bin/env risor
+#!/usr/bin/env risor --
 
 func connect(user="postgres", pass="", host="localhost", port=5432, db="postgres") {
     return pgx.connect('postgres://{user}:{pass}@{host}:{port}/{db}')

--- a/examples/scripts/pipe.tm
+++ b/examples/scripts/pipe.tm
@@ -1,4 +1,4 @@
-#!/usr/bin/env risor
+#!/usr/bin/env risor --
 
 array := ["gophers", "are", "burrowing", "rodents"]
 

--- a/examples/scripts/stargazers.tm
+++ b/examples/scripts/stargazers.tm
@@ -1,3 +1,4 @@
+#!/usr/bin/env risor --
 
 // Returns a list of stargazers for a Github repository
 func get_stargazers(owner='golang', repo='go') {

--- a/examples/scripts/try.tm
+++ b/examples/scripts/try.tm
@@ -1,3 +1,4 @@
+#!/usr/bin/env risor --
 
 x := 0
 


### PR DESCRIPTION
Use `cobra.ArbitraryArgs` and use `--` to separate arguments passed to scripts from arguments to Risor.