### PR TITLE
AWS STS client; retract Tamarin releases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,3 +96,8 @@ require (
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+retract (
+	v1.0.1 // ignores Tamarin release
+	v1.0.0 // ignores Tamarin release
+)

--- a/modules/aws/client.go
+++ b/modules/aws/client.go
@@ -33,6 +33,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sfn"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/aws-sdk-go-v2/service/wafv2"
 	"github.com/risor-io/risor/object"
 	"github.com/risor-io/risor/op"
@@ -175,6 +176,8 @@ func getClient(service string, cfg *Config) object.Object {
 		return NewClient("ecr", ecr.NewFromConfig(cfg.value), cfg)
 	case "ecs":
 		return NewClient("ecs", ecs.NewFromConfig(cfg.value), cfg)
+	case "sts":
+		return NewClient("sts", sts.NewFromConfig(cfg.value), cfg)
 	default:
 		return object.Errorf("unknown aws service: %s", service)
 	}

--- a/object/typeconv.go
+++ b/object/typeconv.go
@@ -144,6 +144,12 @@ func AsBytes(obj Object) ([]byte, *Error) {
 		return obj.value.Bytes(), nil
 	case *String:
 		return []byte(obj.value), nil
+	case io.Reader:
+		bytes, err := io.ReadAll(obj)
+		if err != nil {
+			return nil, NewError(err)
+		}
+		return bytes, nil
 	default:
 		return nil, Errorf("type error: expected bytes (%s given)", obj.Type())
 	}


### PR DESCRIPTION
Ignores Tamarin 1.0.0 and 1.0.1 releases which made it into the Go proxy cache.

Add AWS STS client.