### PR TITLE
Enable importer in the Risor CLI

### DIFF
--- a/examples/go/struct/main.go
+++ b/examples/go/struct/main.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/fatih/color"
+	"github.com/risor-io/risor"
+	"github.com/risor-io/risor/object"
+)
+
+type State struct {
+	Name    string
+	Running bool
+}
+
+type Service struct {
+	name       string
+	running    bool
+	startCount int
+	stopCount  int
+}
+
+func (s *Service) Start() error {
+	if s.running {
+		return fmt.Errorf("service %s already running", s.name)
+	}
+	s.running = true
+	s.startCount++
+	return nil
+}
+
+func (s *Service) Stop() error {
+	if !s.running {
+		return fmt.Errorf("service %s not running", s.name)
+	}
+	s.running = false
+	s.stopCount++
+	return nil
+}
+
+func (s *Service) SetName(name string) {
+	s.name = name
+}
+
+func (s *Service) GetName() string {
+	return s.name
+}
+
+func (s *Service) PrintState() {
+	fmt.Printf("printing state... name: %s running %t\n", s.name, s.running)
+}
+
+func (s *Service) GetMetrics() map[string]interface{} {
+	return map[string]interface{}{
+		"running":     s.running,
+		"start_count": s.startCount,
+		"stop_count":  s.stopCount,
+	}
+}
+
+const defaultExample = `
+svc.SetName("My Service")
+svc.Start()
+svc.PrintState()
+svc.GetMetrics()
+`
+
+var red = color.New(color.FgRed).SprintfFunc()
+
+func main() {
+	var code string
+	flag.StringVar(&code, "code", defaultExample, "Code to evaluate")
+	flag.Parse()
+
+	ctx := context.Background()
+
+	// Initialize the service
+	svc := &Service{}
+
+	// Create a Risor proxy for the service
+	proxy, err := object.NewProxy(svc)
+	if err != nil {
+		fmt.Println(red(err.Error()))
+		os.Exit(1)
+	}
+
+	// Build up options for Risor, including the proxy
+	opt := risor.WithBuiltins(map[string]object.Object{"svc": proxy})
+
+	// Run the Risor code which can access the service as `svc`
+	if _, err = risor.Eval(ctx, code, opt); err != nil {
+		fmt.Println(red(err.Error()))
+		os.Exit(1)
+	}
+
+	fmt.Println(svc.GetMetrics())
+}

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -36,7 +36,7 @@ func NewLocalImporter(opts LocalImporterOptions) *LocalImporter {
 		opts.Builtins = map[string]object.Object{}
 	}
 	if opts.Extensions == nil {
-		opts.Extensions = []string{".tm"}
+		opts.Extensions = []string{".risor", ".rsr"}
 	}
 	return &LocalImporter{
 		builtins:   opts.Builtins,

--- a/internal/cfg/cfg.go
+++ b/internal/cfg/cfg.go
@@ -7,9 +7,10 @@ import (
 )
 
 type RisorConfig struct {
-	Compiler *compiler.Compiler
-	Main     *object.Code
-	Builtins map[string]object.Object
-	Importer importer.Importer
-	Offset   int
+	Compiler        *compiler.Compiler
+	Main            *object.Code
+	Builtins        map[string]object.Object
+	Importer        importer.Importer
+	LocalImportPath string
+	Offset          int
 }

--- a/risor.go
+++ b/risor.go
@@ -78,6 +78,12 @@ func WithImporter(i importer.Importer) Option {
 	}
 }
 
+func WithLocalImporter(path string) Option {
+	return func(r *cfg.RisorConfig) {
+		r.LocalImportPath = path
+	}
+}
+
 func WithCode(c *object.Code) Option {
 	return func(r *cfg.RisorConfig) {
 		r.Main = c
@@ -97,6 +103,15 @@ func Eval(ctx context.Context, source string, options ...Option) (object.Object,
 	}
 	for _, opt := range options {
 		opt(r)
+	}
+
+	// Set up a local module importer if LocalImportPath is set.
+	if r.Importer == nil && r.LocalImportPath != "" {
+		r.Importer = importer.NewLocalImporter(importer.LocalImporterOptions{
+			Builtins:   r.Builtins,
+			SourceDir:  r.LocalImportPath,
+			Extensions: []string{".risor", ".rsr"},
+		})
 	}
 
 	// Initialize a compiler if one was not provided via opts.


### PR DESCRIPTION
A path to library modules may now be supplied with `--modules path/to/modules` with the Risor CLI.

```
risor path/to/app.risor --modules path/to/modules
```

The path defaults to the working directory.
