### PR TITLE
Fix printf behavior

### DIFF
--- a/modules/fmt/fmt.go
+++ b/modules/fmt/fmt.go
@@ -8,11 +8,11 @@ import (
 )
 
 func printableValue(obj object.Object) interface{} {
+	iface := obj.Interface()
+	if iface != nil {
+		return iface
+	}
 	switch obj := obj.(type) {
-	case *object.String:
-		return obj.Value()
-	case *object.NilType:
-		return nil
 	case fmt.Stringer:
 		return obj.String()
 	default:


### PR DESCRIPTION
It now passes the underlying Go object through to the `fmt.Printf` function, which is the desired behavior.