### PR TITLE
Update cat to return a string instead of []byte

### DIFF
--- a/modules/os/os.go
+++ b/modules/os/os.go
@@ -477,7 +477,7 @@ func Cat(ctx context.Context, args ...object.Object) object.Object {
 		}
 		buf.Write(bytes)
 	}
-	return object.NewByteSlice(buf.Bytes())
+	return object.NewString(buf.String())
 }
 
 func Module() *object.Module {


### PR DESCRIPTION
It's typically used for reading text files.