### PR TITLE
Implement stdin using virtual OS mechanisms

### DIFF
--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -180,7 +180,7 @@ func String(ctx context.Context, args ...object.Object) object.Object {
 		if err := lim.TrackCost(argCost); err != nil {
 			return object.NewError(err)
 		}
-		return object.NewString(string(arg.Value()))
+		return object.NewString(string(arg.Value().Bytes()))
 	case *object.ByteSlice:
 		if err := lim.TrackCost(argCost); err != nil {
 			return object.NewError(err)
@@ -261,7 +261,7 @@ func ByteSlice(ctx context.Context, args ...object.Object) object.Object {
 	}
 	switch arg := arg.(type) {
 	case *object.Buffer:
-		return object.NewByteSlice(arg.Value())
+		return object.NewByteSlice(arg.Value().Bytes())
 	case *object.ByteSlice:
 		return arg.Clone()
 	case *object.String:
@@ -308,7 +308,7 @@ func Buffer(ctx context.Context, args ...object.Object) object.Object {
 		if err := lim.TrackCost(arg.Cost()); err != nil {
 			return object.NewError(err)
 		}
-		return object.NewBufferFromBytes(arg.Value())
+		return object.NewBufferFromBytes(arg.Value().Bytes())
 	case *object.ByteSlice:
 		if err := lim.TrackCost(arg.Cost()); err != nil {
 			return object.NewError(err)
@@ -386,7 +386,7 @@ func Any(ctx context.Context, args ...object.Object) object.Object {
 			}
 		}
 	case *object.Buffer:
-		for _, val := range arg.Value() {
+		for _, val := range arg.Value().Bytes() {
 			if val != 0 {
 				return object.True
 			}
@@ -432,7 +432,7 @@ func All(ctx context.Context, args ...object.Object) object.Object {
 			}
 		}
 	case *object.Buffer:
-		for _, val := range arg.Value() {
+		for _, val := range arg.Value().Bytes() {
 			if val == 0 {
 				return object.False
 			}

--- a/modules/fmt/fmt.go
+++ b/modules/fmt/fmt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/risor-io/risor/object"
+	"github.com/risor-io/risor/os"
 )
 
 func printableValue(obj object.Object) interface{} {
@@ -33,7 +34,10 @@ func Printf(ctx context.Context, args ...object.Object) object.Object {
 	for _, arg := range args[1:] {
 		values = append(values, printableValue(arg))
 	}
-	fmt.Printf(format, values...)
+	stdout := os.GetDefaultOS(ctx).Stdout()
+	if _, ioErr := fmt.Fprintf(stdout, format, values...); ioErr != nil {
+		return object.Errorf("io error: %v", ioErr)
+	}
 	return object.Nil
 }
 
@@ -42,7 +46,10 @@ func Println(ctx context.Context, args ...object.Object) object.Object {
 	for _, arg := range args {
 		values = append(values, printableValue(arg))
 	}
-	fmt.Println(values...)
+	stdout := os.GetDefaultOS(ctx).Stdout()
+	if _, ioErr := fmt.Fprintln(stdout, values...); ioErr != nil {
+		return object.Errorf("io error: %v", ioErr)
+	}
 	return object.Nil
 }
 

--- a/modules/os/os.go
+++ b/modules/os/os.go
@@ -139,13 +139,7 @@ func Stat(ctx context.Context, args ...object.Object) object.Object {
 	if ioErr != nil {
 		return object.NewError(ioErr)
 	}
-	return object.NewMap(map[string]object.Object{
-		"name":     object.NewString(info.Name()),
-		"size":     object.NewInt(info.Size()),
-		"mode":     object.NewInt(int64(info.Mode())),
-		"mod_time": object.NewInt(info.ModTime().Unix()),
-		"is_dir":   object.NewBool(info.IsDir()),
-	})
+	return object.NewFileInfo(info)
 }
 
 func TempDir(ctx context.Context, args ...object.Object) object.Object {
@@ -526,5 +520,6 @@ func Builtins() map[string]object.Object {
 		"ls":       object.NewBuiltin("ls", ReadDir),
 		"setenv":   object.NewBuiltin("setenv", Setenv),
 		"unsetenv": object.NewBuiltin("unsetenv", Unsetenv),
+		"open":     object.NewBuiltin("open", Open),
 	}
 }

--- a/modules/os/os.go
+++ b/modules/os/os.go
@@ -11,10 +11,7 @@ import (
 )
 
 func GetOS(ctx context.Context) os.OS {
-	if osObj, found := os.GetOS(ctx); found {
-		return osObj
-	}
-	return os.NewSimpleOS(ctx)
+	return os.GetDefaultOS(ctx)
 }
 
 func Exit(ctx context.Context, args ...object.Object) object.Object {
@@ -509,6 +506,14 @@ func Module() *object.Module {
 		"user_config_dir": object.NewBuiltin("user_config_dir", UserConfigDir),
 		"user_home_dir":   object.NewBuiltin("user_home_dir", UserHomeDir),
 		"write_file":      object.NewBuiltin("write_file", WriteFile),
+		"stdin": object.NewDynamicAttr("stdin", func(ctx context.Context, name string) (object.Object, error) {
+			f := GetOS(ctx).Stdin()
+			return object.NewFile(ctx, f, "/dev/stdin"), nil
+		}),
+		"stdout": object.NewDynamicAttr("stdout", func(ctx context.Context, name string) (object.Object, error) {
+			f := GetOS(ctx).Stdout()
+			return object.NewFile(ctx, f, "/dev/stdout"), nil
+		}),
 	})
 }
 

--- a/object/buffer.go
+++ b/object/buffer.go
@@ -20,8 +20,8 @@ func (b *Buffer) Type() Type {
 	return BUFFER
 }
 
-func (b *Buffer) Value() []byte {
-	return b.value.Bytes()
+func (b *Buffer) Value() *bytes.Buffer {
+	return b.value
 }
 
 func (b *Buffer) Interface() interface{} {

--- a/object/dynamic_attr.go
+++ b/object/dynamic_attr.go
@@ -1,0 +1,84 @@
+package object
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/risor-io/risor/op"
+)
+
+// DynamicAttr is an Object that represents an attribute that can be dynamically
+// resolved to a concrete Object at runtime.
+type DynamicAttr struct {
+	name  string
+	value Object
+	fn    ResolveAttrFunc
+}
+
+func (d *DynamicAttr) Inspect() string {
+	return fmt.Sprintf("dynamic_attr(%s)", d.name)
+}
+
+func (d *DynamicAttr) Type() Type {
+	return DYNAMIC_ATTR
+}
+
+func (d *DynamicAttr) Interface() interface{} {
+	return d.value
+}
+
+func (d *DynamicAttr) String() string {
+	return d.Inspect()
+}
+
+func (d *DynamicAttr) Compare(other Object) (int, error) {
+	return 0, errors.New("type error: unable to compare dynamic_attr")
+}
+
+func (d *DynamicAttr) Equals(other Object) Object {
+	if d == other {
+		return True
+	}
+	return False
+}
+
+func (d *DynamicAttr) IsTruthy() bool {
+	return d.value != nil
+}
+
+func (d *DynamicAttr) RunOperation(opType op.BinaryOpType, right Object) Object {
+	return NewError(fmt.Errorf("eval error: unsupported operation for dynamic_attr: %v", opType))
+}
+
+func (d *DynamicAttr) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("marshal error: unable to marshal dynamic_attr")
+}
+
+func (d *DynamicAttr) GetAttr(name string) (Object, bool) {
+	return nil, false
+}
+
+func (d *DynamicAttr) SetAttr(name string, value Object) error {
+	return errors.New("type error: unable to set attribute on dynamic_attr")
+}
+
+func (d *DynamicAttr) Cost() int {
+	return 0
+}
+
+func (d *DynamicAttr) ResolveAttr(ctx context.Context, name string) (Object, error) {
+	if d.value != nil {
+		return d.value, nil
+	}
+	attr, err := d.fn(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	d.value = attr
+	return attr, nil
+}
+
+func NewDynamicAttr(name string, fn ResolveAttrFunc) *DynamicAttr {
+	return &DynamicAttr{name: name, fn: fn}
+}

--- a/object/file.go
+++ b/object/file.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"sync"
 
+	"github.com/risor-io/risor/limits"
 	"github.com/risor-io/risor/op"
 	ros "github.com/risor-io/risor/os"
 )
@@ -42,22 +44,58 @@ func (f *File) GetAttr(name string) (Object, bool) {
 		return NewInt(position), true
 	case "read":
 		return NewBuiltin("file.read", func(ctx context.Context, args ...Object) Object {
-			if len(args) != 1 {
-				return NewArgsError("file.read", 1, len(args))
+			if len(args) > 1 {
+				return NewArgsRangeError("file.read", 0, 1, len(args))
+			}
+			if len(args) == 0 {
+				stat, err := f.value.Stat()
+				if err != nil {
+					return NewError(err)
+				}
+				size := stat.Size()
+				if size > math.MaxInt32 {
+					return NewError(errors.New("file.read: file size exceeds maximum int32"))
+				}
+				if err := limits.TrackCost(ctx, int(size)); err != nil {
+					return NewError(err)
+				}
+				bytes := make([]byte, size)
+				n, ioErr := f.value.Read(bytes)
+				if ioErr != nil && ioErr != io.EOF {
+					return NewError(ioErr)
+				}
+				return NewByteSlice(bytes[:n])
 			}
 			switch obj := args[0].(type) {
 			case *ByteSlice:
-				n, ioErr := f.Read(obj.Value())
+				slice := obj.Value()
+				n, ioErr := f.Read(slice)
 				if ioErr != nil && ioErr != io.EOF {
 					return NewError(ioErr)
 				}
-				return NewInt(int64(n))
+				if n == len(slice) {
+					return obj
+				}
+				return NewByteSlice(slice[:n])
 			case *Buffer:
-				n, ioErr := f.Read(obj.Value())
+				stat, err := f.value.Stat()
+				if err != nil {
+					return NewError(err)
+				}
+				size := stat.Size()
+				if size > math.MaxInt32 {
+					return NewError(errors.New("file.read: file size exceeds maximum int32"))
+				}
+				if err := limits.TrackCost(ctx, int(size)); err != nil {
+					return NewError(err)
+				}
+				buf := obj.Value()
+				buf.Grow(int(size)) // review: this can panic
+				n, ioErr := f.Read(buf.Bytes())
 				if ioErr != nil && ioErr != io.EOF {
 					return NewError(ioErr)
 				}
-				return NewInt(int64(n))
+				return NewByteSlice(buf.Bytes()[:n])
 			default:
 				return Errorf("type error: file.read expects byte_slice or buffer (%s given)", obj.Type())
 			}
@@ -190,6 +228,10 @@ func (f *File) Cost() int {
 
 func (f *File) MarshalJSON() ([]byte, error) {
 	return nil, errors.New("type error: unable to marshal file")
+}
+
+func (f *File) Iter() Iterator {
+	return NewFileIter(f)
 }
 
 func NewFile(ctx context.Context, value ros.File, path string) *File {

--- a/object/file_iter.go
+++ b/object/file_iter.go
@@ -1,0 +1,119 @@
+package object
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+
+	"github.com/risor-io/risor/op"
+)
+
+type FileIter struct {
+	*base
+	f       *File
+	pos     int64
+	done    bool
+	scanner *bufio.Scanner
+	current Object
+}
+
+func (iter *FileIter) Type() Type {
+	return FILE_ITER
+}
+
+func (iter *FileIter) Inspect() string {
+	return fmt.Sprintf("file_iter(%s)", iter.f.Inspect())
+}
+
+func (iter *FileIter) String() string {
+	return iter.Inspect()
+}
+
+func (iter *FileIter) Interface() interface{} {
+	var entries []map[string]interface{}
+	for {
+		entry, ok := iter.Next()
+		if !ok {
+			break
+		}
+		entries = append(entries, entry.Interface().(map[string]interface{}))
+	}
+	return entries
+}
+
+func (iter *FileIter) Equals(other Object) Object {
+	if iter == other {
+		return True
+	}
+	return False
+}
+
+func (iter *FileIter) GetAttr(name string) (Object, bool) {
+	switch name {
+	case "next":
+		return &Builtin{
+			name: "file_iter.next",
+			fn: func(ctx context.Context, args ...Object) Object {
+				if len(args) != 0 {
+					return NewArgsError("file_iter.next", 0, len(args))
+				}
+				value, ok := iter.Next()
+				if !ok {
+					return Nil
+				}
+				return value
+			},
+		}, true
+	case "entry":
+		return &Builtin{
+			name: "file_iter.entry",
+			fn: func(ctx context.Context, args ...Object) Object {
+				if len(args) != 0 {
+					return NewArgsError("file_iter.entry", 0, len(args))
+				}
+				entry, ok := iter.Entry()
+				if !ok {
+					return Nil
+				}
+				return entry
+			},
+		}, true
+	}
+	return nil, false
+}
+
+func (iter *FileIter) IsTruthy() bool {
+	return !iter.done
+}
+
+func (iter *FileIter) RunOperation(opType op.BinaryOpType, right Object) Object {
+	return NewError(fmt.Errorf("eval error: unsupported operation for file_iter: %v", opType))
+}
+
+func (iter *FileIter) Next() (Object, bool) {
+	if iter.done {
+		return nil, false
+	}
+	if result := iter.scanner.Scan(); !result { // review: can panic
+		iter.done = true
+		return nil, false
+	}
+	iter.current = NewString(iter.scanner.Text())
+	iter.pos++
+	return iter.current, true
+}
+
+func (iter *FileIter) Entry() (IteratorEntry, bool) {
+	if iter.current == nil {
+		return nil, false
+	}
+	return NewEntry(NewInt(iter.pos), iter.current), true
+}
+
+func (iter *FileIter) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("type error: unable to marshal file_iter")
+}
+
+func NewFileIter(f *File) *FileIter {
+	return &FileIter{f: f, pos: -1, scanner: bufio.NewScanner(f)}
+}

--- a/object/object.go
+++ b/object/object.go
@@ -16,7 +16,11 @@
 // name of the object type, such as "string" or "float".
 package object
 
-import "github.com/risor-io/risor/op"
+import (
+	"context"
+
+	"github.com/risor-io/risor/op"
+)
 
 // Type of an object as a string.
 type Type string
@@ -33,10 +37,12 @@ const (
 	COMPLEX       Type = "complex"
 	COMPLEX_SLICE Type = "complex_slice"
 	DIR_ENTRY     Type = "dir_entry"
+	DYNAMIC_ATTR  Type = "dynamic_attr"
 	DURATION      Type = "duration"
 	ERROR         Type = "error"
 	FILE          Type = "file"
 	FILE_INFO     Type = "file_info"
+	FILE_ITER     Type = "file_iter"
 	FILE_MODE     Type = "file_mode"
 	FLOAT         Type = "float"
 	FLOAT_SLICE   Type = "float_slice"
@@ -131,7 +137,13 @@ type Iterator interface {
 	Entry() (IteratorEntry, bool)
 }
 
+// Iterable is an interface that exposes an iterator for an Object.
+type Iterable interface {
+	Iter() Iterator
+}
+
 type Container interface {
+	Iterable
 
 	// GetItem implements the [key] operator for a container type.
 	GetItem(key Object) (Object, *Error)
@@ -150,9 +162,6 @@ type Container interface {
 
 	// Len returns the number of items in this container.
 	Len() *Int
-
-	// Iter returns an iterator for this container.
-	Iter() Iterator
 }
 
 // Hashable types can be hashed and consequently used in a set.
@@ -194,3 +203,10 @@ type HashKey struct {
 	// StrValue is used as the key for strings.
 	StrValue string
 }
+
+// AttrResolver is an interface used to resolve dynamic attributes on an object.
+type AttrResolver interface {
+	ResolveAttr(ctx context.Context, name string) (Object, error)
+}
+
+type ResolveAttrFunc func(ctx context.Context, name string) (Object, error)

--- a/object/typeconv.go
+++ b/object/typeconv.go
@@ -172,6 +172,17 @@ func AsReader(obj Object) (io.Reader, *Error) {
 	}
 }
 
+func AsIterator(obj Object) (Iterator, *Error) {
+	switch obj := obj.(type) {
+	case Iterator:
+		return obj, nil
+	case Iterable:
+		return obj.Iter(), nil
+	default:
+		return nil, Errorf("type error: expected an iterable object (%s given)", obj.Type())
+	}
+}
+
 // *****************************************************************************
 // Converting types from Go to Risor
 // *****************************************************************************

--- a/os/in_memory_file.go
+++ b/os/in_memory_file.go
@@ -1,0 +1,45 @@
+package os
+
+import (
+	"bytes"
+	"errors"
+)
+
+type InMemoryFile struct {
+	buf *bytes.Buffer
+}
+
+func (f *InMemoryFile) Close() error {
+	return nil
+}
+
+func (f *InMemoryFile) Read(p []byte) (n int, err error) {
+	return f.buf.Read(p)
+}
+
+func (f *InMemoryFile) ReadAt(p []byte, off int64) (n int, err error) {
+	return 0, errors.New("io error: read at not supported")
+}
+
+func (f *InMemoryFile) Seek(offset int64, whence int) (int64, error) {
+	return 0, errors.New("io error: seek not supported")
+}
+
+func (f *InMemoryFile) Write(p []byte) (n int, err error) {
+	return f.buf.Write(p)
+}
+
+func (f *InMemoryFile) Stat() (FileInfo, error) {
+	return NewFileInfo(GenericFileInfoOpts{
+		Name: "",
+		Size: int64(f.buf.Len()),
+	}), nil
+}
+
+func (f *InMemoryFile) Bytes() []byte {
+	return f.buf.Bytes()
+}
+
+func NewInMemoryFile(data []byte) *InMemoryFile {
+	return &InMemoryFile{bytes.NewBuffer(data)}
+}

--- a/os/nil_file.go
+++ b/os/nil_file.go
@@ -28,5 +28,8 @@ func (f *NilFile) Write(p []byte) (n int, err error) {
 }
 
 func (f *NilFile) Stat() (FileInfo, error) {
-	return nil, errors.New("io error: unable to stat nil file")
+	return NewFileInfo(GenericFileInfoOpts{
+		Name: "",
+		Size: 0,
+	}), nil
 }

--- a/os/nil_file.go
+++ b/os/nil_file.go
@@ -1,0 +1,32 @@
+package os
+
+import (
+	"errors"
+	"io"
+)
+
+type NilFile struct{}
+
+func (f *NilFile) Close() error {
+	return nil
+}
+
+func (f *NilFile) Read(p []byte) (n int, err error) {
+	return 0, io.EOF
+}
+
+func (f *NilFile) ReadAt(p []byte, off int64) (n int, err error) {
+	return 0, io.EOF
+}
+
+func (f *NilFile) Seek(offset int64, whence int) (int64, error) {
+	return 0, errors.New("io error: unable to seek in nil file")
+}
+
+func (f *NilFile) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}
+
+func (f *NilFile) Stat() (FileInfo, error) {
+	return nil, errors.New("io error: unable to stat nil file")
+}

--- a/os/os.go
+++ b/os/os.go
@@ -62,6 +62,8 @@ type OS interface {
 	UserCacheDir() (string, error)
 	UserConfigDir() (string, error)
 	UserHomeDir() (string, error)
+	Stdin() File
+	Stdout() File
 }
 
 type contextKey string
@@ -79,6 +81,15 @@ func WithOS(ctx context.Context, osObj OS) context.Context {
 func GetOS(ctx context.Context) (OS, bool) {
 	osObj, ok := ctx.Value(osKey).(OS)
 	return osObj, ok
+}
+
+// GetDefaultOS returns the OS from the context, if it exists. Otherwise, it
+// returns a new SimpleOS.
+func GetDefaultOS(ctx context.Context) OS {
+	if osObj, found := GetOS(ctx); found {
+		return osObj
+	}
+	return NewSimpleOS(ctx)
 }
 
 // MassagePathError transforms a fs.PathError into a new one with the base path

--- a/os/simple.go
+++ b/os/simple.go
@@ -130,6 +130,14 @@ func (osObj *SimpleOS) WriteFile(name string, data []byte, perm FileMode) error 
 	return os.WriteFile(name, data, perm)
 }
 
+func (osObj *SimpleOS) Stdin() File {
+	return os.Stdin
+}
+
+func (osObj *SimpleOS) Stdout() File {
+	return os.Stdout
+}
+
 func (osObj *SimpleOS) ReadDir(name string) ([]DirEntry, error) {
 	results, err := os.ReadDir(name)
 	if err != nil {

--- a/os/virtual.go
+++ b/os/virtual.go
@@ -38,6 +38,8 @@ type VirtualOS struct {
 	uid           int
 	mounts        map[string]*Mount
 	exitHandler   ExitHandler
+	stdin         File
+	stdout        File
 }
 
 // Option is a configuration function for a Virtual Machine.
@@ -124,6 +126,20 @@ func WithExitHandler(exitHandler ExitHandler) Option {
 	}
 }
 
+// WithStdin sets the stdin.
+func WithStdin(stdin File) Option {
+	return func(vos *VirtualOS) {
+		vos.stdin = stdin
+	}
+}
+
+// WithStdout sets the stdout.
+func WithStdout(stdout File) Option {
+	return func(vos *VirtualOS) {
+		vos.stdout = stdout
+	}
+}
+
 // NewVirtualOS creates a new VirtualOS configured with the given options.
 func NewVirtualOS(ctx context.Context, opts ...Option) *VirtualOS {
 	vos := &VirtualOS{
@@ -131,6 +147,8 @@ func NewVirtualOS(ctx context.Context, opts ...Option) *VirtualOS {
 		env:    map[string]string{},
 		mounts: map[string]*Mount{},
 		cwd:    "/",
+		stdin:  &NilFile{},
+		stdout: &NilFile{},
 	}
 	if lim, ok := limits.GetLimits(ctx); ok {
 		vos.limits = lim
@@ -378,4 +396,12 @@ func (osObj *VirtualOS) ReadDir(name string) ([]DirEntry, error) {
 		return nil, fmt.Errorf("no such file or directory: %s", name)
 	}
 	return mount.Source.ReadDir(resolvedPath)
+}
+
+func (osObj *VirtualOS) Stdin() File {
+	return osObj.stdin
+}
+
+func (osObj *VirtualOS) Stdout() File {
+	return osObj.stdout
 }

--- a/test.risor
+++ b/test.risor
@@ -1,7 +1,7 @@
 #!/usr/bin/env risor --
 
-func test(a) {
-    return 42
-}
+stdin := os.stdin
 
-test(15)
+for i, line := range stdin {
+    print(i, line)
+}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -380,7 +380,6 @@ func (vm *VirtualMachine) eval(ctx context.Context) error {
 			vm.push(object.NewString(strings.Join(items, "")))
 		case op.Range:
 			iterableObj := vm.pop()
-			fmt.Println("RANGE", iterableObj, iterableObj.Type())
 			iterable, ok := iterableObj.(object.Iterable)
 			if !ok {
 				return fmt.Errorf("type error: object is not an iterable (got %s)",


### PR DESCRIPTION
`os.stdin` and `os.stdout` are now File objects in Risor. They may refer to the _actual_ process stdin and stdout, or they may point to files in a virtual OS filesystem. This means stdin could be attached to an S3 object or something like that, if so desired.

This required adding a new `DynamicAttr` object type, since until now module attributes were always static objects with no special behavior. These stdin and stdout attributes however need the ability to be tied to a context and resolved dynamically.

`println` and `printf` are updated to use the os.stdout File.

A `FileIter` object type is added to allow iterating over the lines in a file, similar to Python's file iterator behavior.

Examples:

```go
for i, line := range os.stdin {
    print(i, line)
}
```

```bash
echo test | risor -c "os.stdin.read()"        
"test\n"
```

https://github.com/risor-io/risor/issues/72

