### PR TITLE
Improved proxying of native Go types

### DIFF
--- a/examples/go/struct/main.go
+++ b/examples/go/struct/main.go
@@ -98,8 +98,10 @@ func main() {
 	}
 
 	// Run the Risor code which can access the service as `svc`
-	if _, err = risor.Eval(ctx, code, opts...); err != nil {
+	result, err := risor.Eval(ctx, code, opts...)
+	if err != nil {
 		fmt.Println(red(err.Error()))
 		os.Exit(1)
 	}
+	fmt.Println("RESULT:", result)
 }

--- a/examples/go/struct/main.go
+++ b/examples/go/struct/main.go
@@ -11,15 +11,9 @@ import (
 	"github.com/risor-io/risor/object"
 )
 
-type Counts struct {
-	Start int
-	Stop  int
-}
-
 type State struct {
 	Name    string
 	Running bool
-	Counts  Counts
 }
 
 type Service struct {
@@ -27,6 +21,10 @@ type Service struct {
 	running    bool
 	startCount int
 	stopCount  int
+}
+
+func (s *State) IsRunning() bool {
+	return s.Running
 }
 
 func (s *Service) Start() error {
@@ -59,31 +57,19 @@ func (s *Service) PrintState() {
 	fmt.Printf("printing state... name: %s running %t\n", s.name, s.running)
 }
 
-func (s *Service) GetState() State {
-	return State{
+func (s *Service) GetState() *State {
+	return &State{
 		Name:    s.name,
 		Running: s.running,
-		Counts: Counts{
-			Start: s.startCount,
-			Stop:  s.stopCount,
-		},
-	}
-}
-
-func (s *Service) GetMetrics() map[string]interface{} {
-	return map[string]interface{}{
-		"running":     s.running,
-		"start_count": s.startCount,
-		"stop_count":  s.stopCount,
 	}
 }
 
 const defaultExample = `
 svc.SetName("My Service")
 svc.Start()
-svc.PrintState()
-print("metrics:", svc.GetMetrics())
-print("start count:", svc.GetState()["Counts"]["Start"])
+state := svc.GetState()
+print("STATE:", state, type(state))
+state.IsRunning()
 `
 
 var red = color.New(color.FgRed).SprintfFunc()
@@ -116,6 +102,4 @@ func main() {
 		fmt.Println(red(err.Error()))
 		os.Exit(1)
 	}
-
-	fmt.Println(svc.GetMetrics())
 }

--- a/object/go_field.go
+++ b/object/go_field.go
@@ -94,7 +94,10 @@ func newGoField(f reflect.StructField) (*GoField, error) {
 	if err != nil {
 		return nil, err
 	}
-	conv := kindConverters[f.Type.Kind()]
+	conv, err := fieldGoType.GetConverter()
+	if err != nil {
+		return nil, err
+	}
 	return &GoField{
 		field:     f,
 		fieldType: fieldGoType,

--- a/object/go_type.go
+++ b/object/go_type.go
@@ -9,7 +9,8 @@ import (
 	"github.com/risor-io/risor/op"
 )
 
-// GoType represents a single Go type whose methods and fields can be proxied.
+// GoType wraps a single native Go type to make it easier to work with in Risor
+// and also to be able to represent the type as a Risor object.
 type GoType struct {
 	*base
 	typ            reflect.Type
@@ -18,9 +19,9 @@ type GoType struct {
 	attributes     map[string]GoAttribute
 	attributeNames []string
 	indirectType   *GoType
-	indirectKind   reflect.Kind
-	warnings       []error
 	converter      TypeConverter
+	isPointerType  bool
+	isDirectMethod map[string]bool
 }
 
 func (t *GoType) Type() Type {
@@ -50,6 +51,8 @@ func (t *GoType) GetAttr(name string) (Object, bool) {
 		return t.packagePath, true
 	case "attributes":
 		return NewMap(t.attrMap()), true
+	case "is_pointer_type":
+		return NewBool(t.isPointerType), true
 	}
 	return nil, false
 }
@@ -83,10 +86,6 @@ func (t *GoType) PackagePath() string {
 	return t.packagePath.value
 }
 
-func (t *GoType) Attributes() map[string]GoAttribute {
-	return t.attributes
-}
-
 func (t *GoType) AttributeNames() []string {
 	return t.attributeNames
 }
@@ -100,27 +99,34 @@ func (t *GoType) ReflectType() reflect.Type {
 	return t.typ
 }
 
-func (t *GoType) Warnings() []error {
-	return t.warnings
-}
-
 func (t *GoType) IsPointerType() bool {
-	return t.indirectType != nil
+	return t.isPointerType
 }
 
-func (t *GoType) IndirectType() (*GoType, bool) {
-	return t.indirectType, t.indirectType != nil
+func (t *GoType) IndirectType() *GoType {
+	return t.indirectType
 }
 
 func (t *GoType) ValueType() *GoType {
-	if t.indirectType != nil {
+	if t.isPointerType {
 		return t.indirectType
 	}
 	return t
 }
 
+func (t *GoType) PointerType() *GoType {
+	if t.isPointerType {
+		return t
+	}
+	return t.indirectType
+}
+
 func (t *GoType) New() reflect.Value {
 	return reflect.New(t.ValueType().typ)
+}
+
+func (t *GoType) HasDirectMethod(name string) bool {
+	return t.isDirectMethod[name]
 }
 
 func (t *GoType) GetConverter() (TypeConverter, error) {
@@ -137,13 +143,15 @@ func (t *GoType) GetConverter() (TypeConverter, error) {
 
 func (t *GoType) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
-		Name       string            `json:"name"`
-		Package    string            `json:"package"`
-		Attributes map[string]Object `json:"attributes"`
+		Name          string            `json:"name"`
+		Package       string            `json:"package"`
+		Attributes    map[string]Object `json:"attributes"`
+		IsPointerType bool              `json:"is_pointer_type"`
 	}{
-		Name:       t.name.value,
-		Package:    t.packagePath.value,
-		Attributes: t.attrMap(),
+		Name:          t.name.value,
+		Package:       t.packagePath.value,
+		Attributes:    t.attrMap(),
+		IsPointerType: t.isPointerType,
 	})
 }
 
@@ -151,19 +159,26 @@ func (t *GoType) MarshalJSON() ([]byte, error) {
 // This is NOT threadsafe. The caller must be holding goTypeMutex.
 func newGoType(typ reflect.Type) (*GoType, error) {
 
-	// Is this type already registered?
-	kind := typ.Kind()
+	// Return the existing type if it's already registered
 	if goType, ok := goTypeRegistry[typ]; ok {
 		return goType, nil
 	}
 
+	// Just like Go does, we want to provide some equivalence between a type and
+	// a pointer to that type. The "indirect type" is the opposite form from
+	// what we're given.
+	kind := typ.Kind()
 	isPointer := kind == reflect.Ptr
-
 	var indirectType reflect.Type
 	var indirectKind reflect.Kind
 	if isPointer {
+		// Get the corresponding non-pointer type
 		indirectType = typ.Elem()
 		indirectKind = indirectType.Kind()
+	} else {
+		// Get the corresponding pointer type
+		indirectType = reflect.PtrTo(typ)
+		indirectKind = reflect.Ptr
 	}
 
 	name := typ.Name()
@@ -173,24 +188,25 @@ func newGoType(typ reflect.Type) (*GoType, error) {
 
 	// Add the new type to the registry
 	goType := &GoType{
-		attributes:   map[string]GoAttribute{},
-		typ:          typ,
-		indirectKind: indirectKind,
-		name:         NewString(name),
-		packagePath:  NewString(typ.PkgPath()),
+		attributes:     map[string]GoAttribute{},
+		typ:            typ,
+		name:           NewString(name),
+		packagePath:    NewString(typ.PkgPath()),
+		isPointerType:  isPointer,
+		isDirectMethod: map[string]bool{},
 	}
+
+	// Add the new type to the registry before calling newGoType recursively
 	goTypeRegistry[typ] = goType
 
-	// Create/lookup the indirect type if there is one
-	if indirectType != nil {
-		indirectGoType, err := newGoType(indirectType)
-		if err != nil {
-			return nil, err
-		}
-		goType.indirectType = indirectGoType
+	// Register the indirect type as well (recursive call!)
+	indirectGoType, err := newGoType(indirectType)
+	if err != nil {
+		return nil, err
 	}
+	goType.indirectType = indirectGoType
 
-	// Discover and register the type of each field for struct types
+	// If this is a struct, discover all its exported fields
 	if kind == reflect.Struct || indirectKind == reflect.Struct {
 		structType := typ
 		if isPointer {
@@ -203,25 +219,29 @@ func newGoType(typ reflect.Type) (*GoType, error) {
 			}
 			goField, err := newGoField(field)
 			if err != nil {
-				goType.warnings = append(goType.warnings, err)
-				continue
+				return nil, err
 			}
 			goType.attributes[field.Name] = goField
 		}
 	}
 
-	// Discover methods and register the types of their inputs and outputs
-	for i := 0; i < typ.NumMethod(); i++ {
-		method := typ.Method(i)
-		if !method.IsExported() {
-			continue
-		}
-		methodGoType, err := newGoMethod(method)
-		if err != nil {
-			goType.warnings = append(goType.warnings, err)
-			continue
-		}
-		goType.attributes[method.Name] = methodGoType
+	// Discover methods on the indirect type
+	indirectMethods, err := getMethods(indirectType)
+	if err != nil {
+		return nil, err
+	}
+	for name, method := range indirectMethods {
+		goType.attributes[name] = method
+	}
+
+	// Discover methods on the direct type (higher precedence)
+	directMethods, err := getMethods(typ)
+	if err != nil {
+		return nil, err
+	}
+	for name, method := range directMethods {
+		goType.attributes[name] = method
+		goType.isDirectMethod[name] = true
 	}
 
 	// Now that all attributes have been discovered, create a sorted list of
@@ -233,9 +253,10 @@ func newGoType(typ reflect.Type) (*GoType, error) {
 	return goType, nil
 }
 
-// NewGoType creates and registers a new GoType for the type of the given Go object.
-// This is safe for use by multiple goroutines. A type registry is maintained
-// behind the scenes to ensure that each type is only registered once.
+// NewGoType registers and returns a Risor GoType for the type of the given
+// native Go object. This is safe for concurrent use by multiple goroutines.
+// A type registry is maintained behind the scenes to ensure that each type
+// is only registered once.
 func NewGoType(typ reflect.Type) (*GoType, error) {
 	goTypeMutex.Lock()
 	defer goTypeMutex.Unlock()

--- a/object/proxy.go
+++ b/object/proxy.go
@@ -73,7 +73,6 @@ func (p *Proxy) GetAttr(name string) (Object, bool) {
 		return p.typ, true
 	}
 	attr, found := p.typ.GetAttribute(name)
-	fmt.Println("Proxy.GetAttr", name, attr, found, p.typ)
 	if !found {
 		return nil, false
 	}
@@ -207,7 +206,6 @@ func (p *Proxy) call(ctx context.Context, m *GoMethod, args ...Object) Object {
 				if err != nil {
 					return Errorf("call error: failed to convert output from %s() call: %s", methodName, err)
 				}
-				fmt.Println("OUT", i, output, reflect.TypeOf(outConv), result)
 				return result
 			}
 		}

--- a/object/proxy_test.go
+++ b/object/proxy_test.go
@@ -228,11 +228,13 @@ func TestProxySetGetAttr(t *testing.T) {
 
 }
 
-func TestAttemptProxyOnStructValue(t *testing.T) {
-	// Cannot create a proxy on a struct value. It has to be a pointer.
-	_, err := object.NewProxy(proxyTestType2{})
-	require.NotNil(t, err)
-	require.Equal(t, "type error: unable to proxy type (object_test.proxyTestType2 given)", err.Error())
+func TestProxyOnStructValue(t *testing.T) {
+	p, err := object.NewProxy(proxyTestType2{A: 99})
+	require.NoError(t, err)
+	require.Equal(t, "proxyTestType2", p.GoType().Name())
+	attr, ok := p.GetAttr("A")
+	require.True(t, ok)
+	require.Equal(t, object.NewInt(99), attr)
 }
 
 func TestProxyBytesBuffer(t *testing.T) {

--- a/object/typeconv_test.go
+++ b/object/typeconv_test.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -169,38 +170,159 @@ func TestSliceConverter(t *testing.T) {
 }
 
 func TestStructConverter(t *testing.T) {
-
 	type foo struct {
 		A int
 		B string
 	}
-
-	c, err := newStructConverter(reflect.TypeOf(foo{}))
-	require.Nil(t, err)
-
 	f := foo{A: 1, B: "two"}
 
-	proxyObj, err := c.From(f)
+	// Create a StructConverter for the type foo
+	c, err := newStructConverter(reflect.TypeOf(f))
 	require.Nil(t, err)
 
+	// "From" should wrap the foo in a Proxy. The Proxy will hold a copy of the
+	// foo struct since it is a value type.
+	proxyObj, err := c.From(f)
+	require.Nil(t, err)
 	proxy, ok := proxyObj.(*Proxy)
 	require.True(t, ok)
-
 	value, ok := proxy.GetAttr("A")
 	require.True(t, ok)
 	require.Equal(t, NewInt(1), value)
-
 	value, ok = proxy.GetAttr("B")
 	require.True(t, ok)
 	require.Equal(t, NewString("two"), value)
 
+	// Given a Proxy, "To" should unwrap it back to a foo struct
 	fObj, err := c.To(proxyObj)
 	require.Nil(t, err)
 	fCopy, ok := fObj.(foo)
 	require.True(t, ok)
+	require.Equal(t, f, fCopy)
 
-	require.Equal(t, 1, fCopy.A)
-	require.Equal(t, "two", fCopy.B)
+	// Given a Map, "To" should unwrap it back to a foo struct
+	fObj, err = c.To(NewMap(map[string]Object{
+		"A": NewInt(1),
+		"B": NewString("two"),
+		"C": NewString("ignored"),
+	}))
+	require.Nil(t, err)
+	fCopy, ok = fObj.(foo)
+	require.True(t, ok)
+	require.Equal(t, f, fCopy)
+}
+
+func TestStructPointerConverter(t *testing.T) {
+	type foo struct {
+		A int
+		B string
+	}
+	f := foo{A: 1, B: "two"}
+	fPtr := &f
+
+	// Create a StructConverter for the pointer type *foo
+	c, err := newStructConverter(reflect.TypeOf(fPtr))
+	require.Nil(t, err)
+
+	// "From" should wrap the *foo in a Proxy
+	proxyObj, err := c.From(fPtr)
+	require.Nil(t, err)
+	proxy, ok := proxyObj.(*Proxy)
+	require.True(t, ok)
+	value, ok := proxy.GetAttr("A")
+	require.True(t, ok)
+	require.Equal(t, NewInt(1), value)
+	value, ok = proxy.GetAttr("B")
+	require.True(t, ok)
+	require.Equal(t, NewString("two"), value)
+
+	// Given a Proxy, "To" should unwrap it back to the exact same *foo pointer
+	fObj, err := c.To(proxyObj)
+	require.Nil(t, err)
+	fPtrCopy, ok := fObj.(*foo)
+	require.True(t, ok)
+	require.Equal(t, fPtr, fPtrCopy)
+
+	// Given a Map, "To" should return a new *foo pointer, where the underlying
+	// foo struct has the same values as the Map
+	fObj, err = c.To(NewMap(map[string]Object{
+		"A": NewInt(1),
+		"B": NewString("two"),
+		"C": NewString("ignored"),
+	}))
+	require.Nil(t, err)
+	fPtrCopy, ok = fObj.(*foo)
+	require.True(t, ok)
+	require.Equal(t, fPtr, fPtrCopy)
+}
+
+type testState struct {
+	Count int
+}
+
+func (s *testState) GetCount() int {
+	return s.Count
+}
+
+type testService struct {
+	Name  string
+	State testState
+}
+
+func (s *testService) GetName() string {
+	return s.Name
+}
+
+func (s *testService) GetState() *testState {
+	return &s.State
+}
+
+func TestNestedStructsConverter(t *testing.T) {
+
+	svc := &testService{
+		Name: "sauron",
+		State: testState{
+			Count: 42,
+		},
+	}
+
+	// Create a StructConverter for the pointer type *testService
+	c, err := newStructConverter(reflect.TypeOf(svc))
+	require.Nil(t, err)
+
+	// "From" should wrap the *testService in a Proxy
+	proxyObj, err := c.From(svc)
+	require.Nil(t, err)
+	proxy, ok := proxyObj.(*Proxy)
+	require.True(t, ok)
+	value, ok := proxy.GetAttr("Name")
+	require.True(t, ok)
+	require.Equal(t, NewString("sauron"), value)
+
+	// Access the State attribute, which is a nested struct
+	value, ok = proxy.GetAttr("State")
+	require.True(t, ok)
+	stateProxy, ok := value.(*Proxy)
+	require.True(t, ok)
+	value, ok = stateProxy.GetAttr("Count")
+	require.True(t, ok)
+	require.Equal(t, NewInt(42), value)
+
+	// Access the GetState method
+	value, ok = proxy.GetAttr("GetState")
+	require.True(t, ok)
+	stateFunc, ok := value.(*Builtin)
+	require.True(t, ok)
+	require.NotNil(t, stateFunc)
+	require.Equal(t, "*object.testService.GetState", stateFunc.Name())
+
+	// Call GetState and confirm a Proxy is returned that wraps the *testState
+	result := stateFunc.Call(context.Background())
+	resultProxy, ok := result.(*Proxy)
+	require.True(t, ok)
+	value, ok = resultProxy.GetAttr("Count")
+	require.True(t, ok)
+	require.Equal(t, NewInt(42), value)
 }
 
 func TestTimeConverter(t *testing.T) {

--- a/object/typeconv_test.go
+++ b/object/typeconv_test.go
@@ -180,22 +180,27 @@ func TestStructConverter(t *testing.T) {
 
 	f := foo{A: 1, B: "two"}
 
-	tF, err := c.From(f)
-	require.Nil(t, err)
-	require.Equal(t, NewMap(map[string]Object{
-		"A": NewInt(1),
-		"B": NewString("two"),
-	}), tF)
-
-	gF, err := c.To(NewMap(map[string]Object{
-		"A": NewInt(3),
-		"B": NewString("four"),
-	}))
+	proxyObj, err := c.From(f)
 	require.Nil(t, err)
 
-	gFStruct, ok := gF.(foo)
+	proxy, ok := proxyObj.(*Proxy)
 	require.True(t, ok)
-	require.Equal(t, foo{A: 3, B: "four"}, gFStruct)
+
+	value, ok := proxy.GetAttr("A")
+	require.True(t, ok)
+	require.Equal(t, NewInt(1), value)
+
+	value, ok = proxy.GetAttr("B")
+	require.True(t, ok)
+	require.Equal(t, NewString("two"), value)
+
+	fObj, err := c.To(proxyObj)
+	require.Nil(t, err)
+	fCopy, ok := fObj.(foo)
+	require.True(t, ok)
+
+	require.Equal(t, 1, fCopy.A)
+	require.Equal(t, "two", fCopy.B)
 }
 
 func TestTimeConverter(t *testing.T) {


### PR DESCRIPTION
This PR adds support for several more situation when it comes to wrapping Go types with Risor. In particular, nested structs can now be interacted with via both methods and fields. Also made it possible for Risor to work with both struct pointers and struct values in some cases where previously only one or the other worked.