### PR TITLE
exec.command, fixes, setattr

### DIFF
--- a/ast/statements.go
+++ b/ast/statements.go
@@ -429,3 +429,46 @@ func (p *Postfix) String() string {
 	out.WriteString(")")
 	return out.String()
 }
+
+// SetAttr is a statement node that describes setting an attribute on an object.
+type SetAttr struct {
+	token token.Token
+
+	// object whose attribute is being accessed
+	object Expression
+
+	// The attribute itself
+	attribute *Ident
+
+	// The value for the attribute
+	value Expression
+}
+
+// NewSetAttr creates a new SetAttr node.
+func NewSetAttr(token token.Token, object Expression, attribute *Ident, value Expression) *SetAttr {
+	return &SetAttr{token: token, object: object, attribute: attribute, value: value}
+}
+
+func (p *SetAttr) StatementNode() {}
+
+func (e *SetAttr) IsExpression() bool { return false }
+
+func (e *SetAttr) Token() token.Token { return e.token }
+
+func (e *SetAttr) Literal() string { return e.token.Literal }
+
+func (e *SetAttr) Object() Expression { return e.object }
+
+func (e *SetAttr) Name() string { return e.attribute.value }
+
+func (e *SetAttr) Value() Expression { return e.value }
+
+func (e *SetAttr) String() string {
+	var out bytes.Buffer
+	out.WriteString(e.object.String())
+	out.WriteString(".")
+	out.WriteString(e.attribute.value)
+	out.WriteString(" = ")
+	out.WriteString(e.value.String())
+	return out.String()
+}

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -2,6 +2,7 @@
 package builtins
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -307,7 +308,7 @@ func Buffer(ctx context.Context, args ...object.Object) object.Object {
 		return err
 	}
 	if len(args) == 0 {
-		return object.NewBuffer(nil)
+		return object.NewBuffer(new(bytes.Buffer))
 	}
 	arg := args[0]
 	lim, ok := limits.GetLimits(ctx)

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -572,8 +572,6 @@ func Call(ctx context.Context, args ...object.Object) object.Object {
 		return err
 	}
 	switch fn := args[0].(type) {
-	case *object.Builtin:
-		return fn.Call(ctx, args[1:]...)
 	case *object.Function:
 		callFunc, found := object.GetCallFunc(ctx)
 		if !found {
@@ -584,6 +582,8 @@ func Call(ctx context.Context, args ...object.Object) object.Object {
 			return object.Errorf(err.Error())
 		}
 		return result
+	case object.Callable:
+		return fn.Call(ctx, args[1:]...)
 	default:
 		return object.Errorf("type error: call() unsupported argument (%s given)", args[0].Type())
 	}
@@ -768,7 +768,7 @@ func Try(ctx context.Context, args ...object.Object) object.Object {
 			default:
 				return result, nil
 			}
-		case *object.Builtin:
+		case object.Callable:
 			result := obj.Call(ctx)
 			switch result := result.(type) {
 			case *object.Error:

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -110,7 +110,11 @@ func (c *Compiler) Code() *Code {
 // Compile the given AST node and return the compiled code object.
 func (c *Compiler) Compile(node ast.Node) (*Code, error) {
 	c.failure = nil
-	c.main.source = node.String()
+	if c.main.source == "" {
+		c.main.source = node.String()
+	} else {
+		c.main.source = fmt.Sprintf("%s\n%s", c.main.source, node.String())
+	}
 	if err := c.compile(node); err != nil {
 		return nil, err
 	}

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -257,6 +257,10 @@ func (c *Compiler) compile(node ast.Node) error {
 		if err := c.compileMultiVar(node); err != nil {
 			return err
 		}
+	case *ast.SetAttr:
+		if err := c.compileSetAttr(node); err != nil {
+			return err
+		}
 	default:
 		panic(fmt.Sprintf("compile error: unknown ast node type: %T", node))
 	}
@@ -1144,6 +1148,18 @@ func (c *Compiler) compileAssign(node *ast.Assign) error {
 	case Free:
 		c.emit(op.StoreFree, uint16(resolution.freeIndex))
 	}
+	return nil
+}
+
+func (c *Compiler) compileSetAttr(node *ast.SetAttr) error {
+	if err := c.compile(node.Value()); err != nil {
+		return err
+	}
+	if err := c.compile(node.Object()); err != nil {
+		return err
+	}
+	idx := c.current.addName(node.Name())
+	c.emit(op.StoreAttr, idx)
 	return nil
 }
 

--- a/internal/cfg/cfg.go
+++ b/internal/cfg/cfg.go
@@ -8,6 +8,7 @@ import (
 	"github.com/risor-io/risor/importer"
 	modBase64 "github.com/risor-io/risor/modules/base64"
 	modBytes "github.com/risor-io/risor/modules/bytes"
+	modExec "github.com/risor-io/risor/modules/exec"
 	modFetch "github.com/risor-io/risor/modules/fetch"
 	modFmt "github.com/risor-io/risor/modules/fmt"
 	modHash "github.com/risor-io/risor/modules/hash"
@@ -90,16 +91,17 @@ func (cfg *RisorConfig) addDefaultGlobals() {
 	}
 	// Add default modules
 	modules := map[string]object.Object{
-		"math":    modMath.Module(),
+		"base64":  modBase64.Module(),
+		"bytes":   modBytes.Module(),
+		"exec":    modExec.Module(),
+		"fmt":     modFmt.Module(),
 		"json":    modJson.Module(),
-		"strings": modStrings.Module(),
-		"time":    modTime.Module(),
+		"math":    modMath.Module(),
+		"os":      modOs.Module(),
 		"rand":    modRand.Module(),
 		"strconv": modStrconv.Module(),
-		"os":      modOs.Module(),
-		"bytes":   modBytes.Module(),
-		"base64":  modBase64.Module(),
-		"fmt":     modFmt.Module(),
+		"strings": modStrings.Module(),
+		"time":    modTime.Module(),
 	}
 	addGlobals(modules)
 }

--- a/modules/all/all.go
+++ b/modules/all/all.go
@@ -4,6 +4,7 @@ import (
 	"github.com/risor-io/risor/builtins"
 	modBase64 "github.com/risor-io/risor/modules/base64"
 	modBytes "github.com/risor-io/risor/modules/bytes"
+	modExec "github.com/risor-io/risor/modules/exec"
 	modFetch "github.com/risor-io/risor/modules/fetch"
 	modFmt "github.com/risor-io/risor/modules/fmt"
 	modHash "github.com/risor-io/risor/modules/hash"
@@ -19,16 +20,17 @@ import (
 
 func Builtins() map[string]object.Object {
 	result := map[string]object.Object{
-		"math":    modMath.Module(),
+		"base64":  modBase64.Module(),
+		"bytes":   modBytes.Module(),
+		"exec":    modExec.Module(),
+		"fmt":     modFmt.Module(),
 		"json":    modJson.Module(),
-		"strings": modStrings.Module(),
-		"time":    modTime.Module(),
+		"math":    modMath.Module(),
+		"os":      modOs.Module(),
 		"rand":    modRand.Module(),
 		"strconv": modStrconv.Module(),
-		"os":      modOs.Module(),
-		"bytes":   modBytes.Module(),
-		"base64":  modBase64.Module(),
-		"fmt":     modFmt.Module(),
+		"strings": modStrings.Module(),
+		"time":    modTime.Module(),
 	}
 	for k, v := range modFetch.Builtins() {
 		result[k] = v

--- a/modules/exec/command.go
+++ b/modules/exec/command.go
@@ -1,0 +1,204 @@
+package exec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/risor-io/risor/object"
+	"github.com/risor-io/risor/op"
+)
+
+type Command struct {
+	value  *exec.Cmd
+	stdin  object.Object
+	stdout object.Object
+	stderr object.Object
+}
+
+func (c *Command) Inspect() string {
+	var args []string
+	for _, arg := range c.value.Args {
+		args = append(args, fmt.Sprintf("%q", arg))
+	}
+	return fmt.Sprintf("exec.command(%s)", strings.Join(args, ", "))
+}
+
+func (c *Command) Type() object.Type {
+	return "exec.command"
+}
+
+func (c *Command) Value() *exec.Cmd {
+	return c.value
+}
+
+func (c *Command) GetAttr(name string) (object.Object, bool) {
+	switch name {
+	case "path":
+		return object.NewString(c.value.Path), true
+	case "dir":
+		return object.NewString(c.value.Dir), true
+	case "env":
+		var env []object.Object
+		for _, e := range c.value.Env {
+			env = append(env, object.NewString(e))
+		}
+		return object.NewList(env), true
+	case "stdin":
+		if c.stdin == nil {
+			return object.Nil, true
+		}
+		return c.stdin, true
+	case "stdout":
+		if c.stdout == nil {
+			return object.Nil, true
+		}
+		return c.stdout, true
+	case "stderr":
+		if c.stderr == nil {
+			return object.Nil, true
+		}
+		return c.stderr, true
+	case "run":
+		return object.NewBuiltin("exec.command.run", func(ctx context.Context, args ...object.Object) object.Object {
+			if err := c.value.Run(); err != nil {
+				return object.NewError(err)
+			}
+			return object.Nil
+		}), true
+	case "combined_output":
+		return object.NewBuiltin("exec.command.combined_output", func(ctx context.Context, args ...object.Object) object.Object {
+			output, err := c.value.CombinedOutput()
+			if err != nil {
+				return object.NewError(err)
+			}
+			return object.NewByteSlice(output)
+		}), true
+	case "environ":
+		return object.NewBuiltin("exec.command.environ", func(ctx context.Context, args ...object.Object) object.Object {
+			env := c.value.Environ()
+			var envStr []object.Object
+			for _, e := range env {
+				envStr = append(envStr, object.NewString(e))
+			}
+			return object.NewList(envStr)
+		}), true
+	case "output":
+		return object.NewBuiltin("exec.command.output", func(ctx context.Context, args ...object.Object) object.Object {
+			output, err := c.value.Output()
+			if err != nil {
+				return object.NewError(err)
+			}
+			return object.NewByteSlice(output)
+		}), true
+	case "start":
+		return object.NewBuiltin("exec.command.start", func(ctx context.Context, args ...object.Object) object.Object {
+			if err := c.value.Start(); err != nil {
+				return object.NewError(err)
+			}
+			return object.Nil
+		}), true
+	case "wait":
+		return object.NewBuiltin("exec.command.wait", func(ctx context.Context, args ...object.Object) object.Object {
+			if err := c.value.Wait(); err != nil {
+				return object.NewError(err)
+			}
+			return object.Nil
+		}), true
+	}
+	return nil, false
+}
+
+func (c *Command) SetAttr(name string, value object.Object) error {
+	switch name {
+	case "path":
+		path, err := object.AsString(value)
+		if err != nil {
+			return err.Value()
+		}
+		c.value.Path = path
+	case "dir":
+		dir, err := object.AsString(value)
+		if err != nil {
+			return err.Value()
+		}
+		c.value.Dir = dir
+	case "env":
+		env, err := object.AsList(value)
+		if err != nil {
+			return err.Value()
+		}
+		var envStr []string
+		for _, e := range env.Value() {
+			item, err := object.AsString(e)
+			if err != nil {
+				return err.Value()
+			}
+			envStr = append(envStr, item)
+		}
+		c.value.Env = envStr
+	case "stdin":
+		stdin, err := object.AsReader(value)
+		if err != nil {
+			return err.Value()
+		}
+		c.value.Stdin = stdin
+		c.stdin = value
+	case "stdout":
+		stdout, err := object.AsWriter(value)
+		if err != nil {
+			return err.Value()
+		}
+		c.value.Stdout = stdout
+		c.stdout = value
+	case "stderr":
+		stderr, err := object.AsWriter(value)
+		if err != nil {
+			return err.Value()
+		}
+		c.value.Stderr = stderr
+		c.stderr = value
+	}
+	return fmt.Errorf("attribute error: exec.command object has no attribute %q", name)
+}
+
+func (c *Command) Interface() interface{} {
+	return c.value
+}
+
+func (c *Command) String() string {
+	return c.Inspect()
+}
+
+func (c *Command) Compare(other object.Object) (int, error) {
+	return 0, errors.New("type error: unable to compare exec.command")
+}
+
+func (c *Command) Equals(other object.Object) object.Object {
+	if c == other {
+		return object.True
+	}
+	return object.False
+}
+
+func (c *Command) IsTruthy() bool {
+	return true
+}
+
+func (c *Command) RunOperation(opType op.BinaryOpType, right object.Object) object.Object {
+	return object.NewError(fmt.Errorf("eval error: unsupported operation for exec.command: %v ", opType))
+}
+
+func (c *Command) Cost() int {
+	return 8
+}
+
+func (c *Command) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("type error: unable to marshal exec.command")
+}
+
+func NewCommand(cmd *exec.Cmd) *Command {
+	return &Command{value: cmd}
+}

--- a/modules/exec/command.go
+++ b/modules/exec/command.go
@@ -160,8 +160,10 @@ func (c *Command) SetAttr(name string, value object.Object) error {
 		}
 		c.value.Stderr = stderr
 		c.stderr = value
+	default:
+		return fmt.Errorf("attribute error: exec.command object has no attribute %q", name)
 	}
-	return fmt.Errorf("attribute error: exec.command object has no attribute %q", name)
+	return nil
 }
 
 func (c *Command) Interface() interface{} {

--- a/modules/exec/exec.go
+++ b/modules/exec/exec.go
@@ -1,0 +1,50 @@
+package exec
+
+import (
+	"context"
+	"os/exec"
+
+	"github.com/risor-io/risor/internal/arg"
+	"github.com/risor-io/risor/object"
+)
+
+func CommandFunc(ctx context.Context, args ...object.Object) object.Object {
+	if err := arg.RequireRange("command", 1, 1000, args); err != nil {
+		return err
+	}
+	name, err := object.AsString(args[0])
+	if err != nil {
+		return err
+	}
+	var strArgs []string
+	for _, arg := range args[1:] {
+		argStr, err := object.AsString(arg)
+		if err != nil {
+			return err
+		}
+		strArgs = append(strArgs, argStr)
+	}
+	return NewCommand(exec.Command(name, strArgs...))
+}
+
+func LookPath(ctx context.Context, args ...object.Object) object.Object {
+	if err := arg.Require("look_path", 1, args); err != nil {
+		return err
+	}
+	path, err := object.AsString(args[0])
+	if err != nil {
+		return err
+	}
+	result, execErr := exec.LookPath(path)
+	if err != nil {
+		return object.NewError(execErr)
+	}
+	return object.NewString(result)
+}
+
+func Module() *object.Module {
+	return object.NewBuiltinsModule("exec", map[string]object.Object{
+		"command":   object.NewBuiltin("exec.command", CommandFunc),
+		"look_path": object.NewBuiltin("exec.look_path", LookPath),
+	})
+}

--- a/object/object.go
+++ b/object/object.go
@@ -165,6 +165,13 @@ type Container interface {
 	Len() *Int
 }
 
+// Callable is an interface that exposes a Call method.
+type Callable interface {
+
+	// Call invokes the callable with the given arguments and returns the result.
+	Call(ctx context.Context, args ...Object) Object
+}
+
 // Hashable types can be hashed and consequently used in a set.
 type Hashable interface {
 

--- a/object/typeconv.go
+++ b/object/typeconv.go
@@ -172,6 +172,19 @@ func AsReader(obj Object) (io.Reader, *Error) {
 	}
 }
 
+func AsWriter(obj Object) (io.Writer, *Error) {
+	switch obj := obj.(type) {
+	case *Buffer:
+		return obj.value, nil
+	case *File:
+		return obj.value, nil
+	case io.Writer:
+		return obj, nil
+	default:
+		return nil, Errorf("type error: expected a writable object (%s given)", obj.Type())
+	}
+}
+
 func AsIterator(obj Object) (Iterator, *Error) {
 	switch obj := obj.(type) {
 	case Iterator:

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -7,6 +7,7 @@ package parser
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -1136,6 +1137,7 @@ func (p *Parser) parseAssign(name ast.Node) ast.Node {
 	case *ast.Index:
 		index = node
 	default:
+		fmt.Println("parseAssign", name, reflect.TypeOf(name))
 		p.setTokenError(operator, "unexpected token for assignment: %s", name.Literal())
 		return nil
 	}
@@ -1358,6 +1360,15 @@ func (p *Parser) parseGetAttr(objNode ast.Node) ast.Node {
 			return nil
 		}
 		return ast.NewObjectCall(period, obj, call)
+	} else if p.peekTokenIs(token.ASSIGN) {
+		p.nextToken() // move to the "="
+		p.nextToken() // move to the value
+		right := p.parseExpression(LOWEST)
+		if right == nil {
+			p.setTokenError(p.curToken, "invalid assignment statement value")
+			return nil
+		}
+		return ast.NewSetAttr(obj.Token(), obj, name, right)
 	}
 	return ast.NewGetAttr(period, obj, name)
 }

--- a/vm/run.go
+++ b/vm/run.go
@@ -7,6 +7,7 @@ import (
 	"github.com/risor-io/risor/compiler"
 	"github.com/risor-io/risor/importer"
 	modBytes "github.com/risor-io/risor/modules/bytes"
+	modExec "github.com/risor-io/risor/modules/exec"
 	modFmt "github.com/risor-io/risor/modules/fmt"
 	modJson "github.com/risor-io/risor/modules/json"
 	modMath "github.com/risor-io/risor/modules/math"
@@ -72,6 +73,7 @@ func basicBuiltins() map[string]any {
 		"rand":    modRand.Module(),
 		"strconv": modStrconv.Module(),
 		"bytes":   modBytes.Module(),
+		"exec":    modExec.Module(),
 	}
 	for k, v := range builtins.Builtins() {
 		globals[k] = v

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -1554,6 +1554,36 @@ func TestCloneWithAnonymousFunc(t *testing.T) {
 	require.Equal(t, object.NewInt(3), value)
 }
 
+func TestIncrementalEvaluation(t *testing.T) {
+	ctx := context.Background()
+	ast, err := parser.Parse(ctx, "x := 3")
+	require.Nil(t, err)
+
+	comp, err := compiler.New()
+	require.Nil(t, err)
+	main, err := comp.Compile(ast)
+	require.Nil(t, err)
+
+	v := New(main)
+	require.Nil(t, v.Run(ctx))
+	value, err := v.Get("x")
+	require.Nil(t, err)
+	require.Equal(t, object.NewInt(3), value)
+
+	ast, err = parser.Parse(ctx, "x + 7")
+	require.Nil(t, err)
+	_, err = comp.Compile(ast)
+	require.Nil(t, err)
+	require.Nil(t, v.Run(ctx))
+	value, err = v.Get("x")
+	require.Nil(t, err)
+	require.Equal(t, object.NewInt(3), value)
+
+	tos, ok := v.TOS()
+	require.True(t, ok)
+	require.Equal(t, object.NewInt(10), tos)
+}
+
 func TestImports(t *testing.T) {
 	tests := []testCase{
 		{`import simple_math; simple_math.add(3, 4)`, object.NewInt(7)},


### PR DESCRIPTION
- Add `exec` module
- Fix `buffer()` creation with no args
- Support set attr for `exec.command`
- Add `object.Callable` interface and switch to that instead of a concrete type
- Fix incremental evaluation in the REPL