### PR TITLE
Fix REPL eval after previous error

### DIFF
--- a/cmd/risor/repl/repl.go
+++ b/cmd/risor/repl/repl.go
@@ -201,6 +201,9 @@ func getEvaluator(cfg *cfg.RisorConfig) func(ctx context.Context, source string)
 			v = vm.New(code, cfg.VMOpts()...)
 		}
 		if err := v.Run(ctx); err != nil {
+			// Update the IP to be after the last instruction, so that next
+			// time around we start in the right location.
+			v.SetIP(code.InstructionCount())
 			color.Red(err.Error())
 			return nil, err
 		}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -625,6 +625,16 @@ func (vm *VirtualMachine) call(ctx context.Context, fn object.Object, argc int) 
 	return nil
 }
 
+// GetIP returns the current instruction pointer.
+func (vm *VirtualMachine) GetIP() int {
+	return vm.ip
+}
+
+// SetIP sets the current instruction pointer.
+func (vm *VirtualMachine) SetIP(value int) {
+	vm.ip = value
+}
+
 func (vm *VirtualMachine) TOS() (object.Object, bool) {
 	if vm.sp >= 0 {
 		return vm.stack[vm.sp], true


### PR DESCRIPTION
In the REPL, after an error, the instruction pointer was not moved forward before. This meant that upon the next evaluation the VM started execution on old instructions.

This finishes the fixes for https://github.com/risor-io/risor/issues/97