### PR TITLE
Additional test cases and minor error message improvements

### DIFF
--- a/importer/importer.go
+++ b/importer/importer.go
@@ -64,7 +64,7 @@ func (i *LocalImporter) Import(ctx context.Context, name string) (*object.Module
 	}
 	source, found := readFileWithExtensions(i.sourceDir, name, i.extensions)
 	if !found {
-		return nil, fmt.Errorf("module not found: %s", name)
+		return nil, fmt.Errorf("import error: module %q not found", name)
 	}
 	ast, err := parser.Parse(ctx, source)
 	if err != nil {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -699,7 +699,7 @@ func (p *Parser) parseImport() ast.Node {
 
 func (p *Parser) parseFromImport() ast.Node {
 	fromToken := p.curToken
-	if !p.expectPeek("an from-import statement", token.IDENT) {
+	if !p.expectPeek("a from-import statement", token.IDENT) {
 		return nil
 	}
 	parentModule := make([]*ast.Ident, 0)
@@ -726,14 +726,14 @@ func (p *Parser) parseFromImport() ast.Node {
 		}))
 		return nil
 	}
-	if !p.expectPeek("an from-import statement", token.IDENT) {
+	if !p.expectPeek("a from-import statement", token.IDENT) {
 		return nil
 	}
 	moduleName := ast.NewIdent(p.curToken)
 	var alias *ast.Ident
 	if p.peekTokenIs(token.AS) {
 		p.nextToken()
-		if !p.expectPeek("an from-import statement", token.IDENT) {
+		if !p.expectPeek("a from-import statement", token.IDENT) {
 			return nil
 		}
 		alias = ast.NewIdent(p.curToken)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -136,6 +136,13 @@ func (vm *VirtualMachine) Run(ctx context.Context) (err error) {
 		return err
 	}
 
+	// Add any globals that are modules cache
+	for name, value := range vm.globals {
+		if module, ok := value.(*object.Module); ok {
+			vm.modules[name] = module
+		}
+	}
+
 	// Keep `running` flag up-to-date
 	vm.running = true
 	defer func() { vm.running = false }()
@@ -523,7 +530,8 @@ func (vm *VirtualMachine) eval(ctx context.Context) error {
 				}
 				attr, found := module.GetAttr(name.String())
 				if !found {
-					return fmt.Errorf("exec error: symbol not found: %s", name.String())
+					return fmt.Errorf("import error: cannot import name %q from %q",
+						name.String(), module.Name())
 				}
 				vm.push(attr)
 			}
@@ -589,6 +597,7 @@ func (vm *VirtualMachine) eval(ctx context.Context) error {
 }
 
 func (vm *VirtualMachine) loadModule(ctx context.Context, name string) (*object.Module, error) {
+	fmt.Println("loadModule", name, vm.modules[name])
 	if module, ok := vm.modules[name]; ok {
 		return module, nil
 	}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -597,7 +597,6 @@ func (vm *VirtualMachine) eval(ctx context.Context) error {
 }
 
 func (vm *VirtualMachine) loadModule(ctx context.Context, name string) (*object.Module, error) {
-	fmt.Println("loadModule", name, vm.modules[name])
 	if module, ok := vm.modules[name]; ok {
 		return module, nil
 	}


### PR DESCRIPTION
- Use "import error:" as the common prefix for import related errors
- Add modules in globals to the modules cache, to support importing from them
- Add test cases for bad imports