### PR TITLE
Added completions

### DIFF
--- a/cmd/risor/main.go
+++ b/cmd/risor/main.go
@@ -50,6 +50,8 @@ func main() {
 	}
 
 	cmdVersion.Flags().StringP("output", "o", "", "Set the output format")
+	cmdVersion.RegisterFlagCompletionFunc("output",
+		cobra.FixedCompletions(outputFormatsCompletion, cobra.ShellCompDirectiveNoFileComp))
 
 	rootCmd.AddCommand(cmdServe)
 	rootCmd.AddCommand(cmdVersion)


### PR DESCRIPTION
Adds completions to `risor` command:

- file completion on argument
- output format completion on `--output` flag

Using Risor with completions means you have to type in the file paths manually, which isn't super.

Sadly, I was not able to find a way to combine the sub-command completions with the file completions. So I wrote a simple function that does file completions in Go.
