### PR TITLE
import statement support alias

### DIFF
--- a/ast/statements.go
+++ b/ast/statements.go
@@ -374,11 +374,12 @@ func (a *Assign) String() string {
 type Import struct {
 	token token.Token // the "import" token
 	name  *Ident      // name of the module to import
+	alias *Ident      // alias for the module
 }
 
 // NewImport creates a new Import node.
-func NewImport(token token.Token, name *Ident) *Import {
-	return &Import{token: token, name: name}
+func NewImport(token token.Token, name *Ident, alias *Ident) *Import {
+	return &Import{token: token, name: name, alias: alias}
 }
 
 func (i *Import) StatementNode() {}
@@ -391,10 +392,15 @@ func (i *Import) Literal() string { return i.token.Literal }
 
 func (i *Import) Module() *Ident { return i.name }
 
+func (i *Import) Alias() *Ident { return i.alias }
+
 func (i *Import) String() string {
 	var out bytes.Buffer
 	out.WriteString(i.Literal() + " ")
 	out.WriteString(i.name.Literal())
+	if i.alias != nil {
+		out.WriteString(" as " + i.alias.Literal())
+	}
 	out.WriteString(";")
 	return out.String()
 }

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -559,6 +559,9 @@ func (c *Compiler) compileImport(node *ast.Import) error {
 	name := node.Module().String()
 	c.emit(op.LoadConst, c.constant(name))
 	c.emit(op.Import)
+	if node.Alias() != nil {
+		name = node.Alias().String()
+	}
 	var sym *Symbol
 	var found bool
 	sym, found = c.current.symbols.Get(name)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -694,7 +694,16 @@ func (p *Parser) parseImport() ast.Node {
 	if !p.expectPeek("an import statement", token.IDENT) {
 		return nil
 	}
-	return ast.NewImport(importToken, ast.NewIdent(p.curToken))
+	name := ast.NewIdent(p.curToken)
+	var alias *ast.Ident
+	if p.peekTokenIs(token.AS) {
+		p.nextToken()
+		if !p.expectPeek("an import statement", token.IDENT) {
+			return nil
+		}
+		alias = ast.NewIdent(p.curToken)
+	}
+	return ast.NewImport(importToken, name, alias)
 }
 
 func (p *Parser) parseFromImport() ast.Node {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -1590,6 +1590,8 @@ func TestImports(t *testing.T) {
 		{`import simple_math; int(simple_math.pi)`, object.NewInt(3)},
 		{`import data; data.mydata["count"]`, object.NewInt(1)},
 		{`import data; data.mydata["count"] = 3; data.mydata["count"]`, object.NewInt(3)},
+		{`import data as d; d.mydata["count"]`, object.NewInt(1)},
+		{`import math as m; m.min([3,-7,9])`, object.NewInt(-7)},
 	}
 	runTests(t, tests)
 }
@@ -1614,6 +1616,8 @@ func TestBadImports(t *testing.T) {
 	}
 	tests := []testCase{
 		{`import foo`, `import error: module "foo" not found`},
+		{`import foo as bar`, `import error: module "foo" not found`},
+		{`import math as`, `parse error: unexpected end of file while parsing an import statement (expected identifier)`},
 		{`from foo import bar`, `import error: module "foo" not found`},
 		{`from a.b import c`, `import error: module "a/b" not found`},
 		{`from a.b import c as d`, `import error: module "a/b" not found`},


### PR DESCRIPTION
* Feature Enhancement: Enabled renaming capability within import statements.
* Syntax Example: Now supports import module as renamed_module.
## Details
This enhancement augments the existing import statement by enabling the renaming of imported modules. It introduces the use of the as keyword to rename modules during import, offering developers more control over naming conventions.

## Examples
Renaming a Built-in Module:

``` python
# Original import
import math

# With renaming
import math as m
m.min([1, -8, 10])
```

Renaming an External File:

```python
# Original import
import data

# With renaming
import data as d

```