### PR TITLE
Added Go build tag note to modules

### DIFF
--- a/modules/aws/aws.md
+++ b/modules/aws/aws.md
@@ -1,4 +1,11 @@
+import { Callout } from 'nextra/components';
+
 # aws
+
+<Callout type="info" emoji="ℹ️">
+  This module requires that Risor has been compiled with the `aws` Go build tag.
+  When compiling **manually**, [make sure you specify `-tags aws`](https://github.com/risor-io/risor#build-and-install-the-cli-from-source).
+</Callout>
 
 The `aws` module exposes a simple interface that wraps the AWS SDK v2 for Go.
 Create a client by providing the name of the service you want to use. All API

--- a/modules/kubernetes/kubernetes.md
+++ b/modules/kubernetes/kubernetes.md
@@ -1,4 +1,11 @@
+import { Callout } from 'nextra/components';
+
 # kubernetes
+
+<Callout type="info" emoji="ℹ️">
+  This module requires that Risor has been compiled with the `k8s` Go build tag.
+  When compiling **manually**, [make sure you specify `-tags k8s`](https://github.com/risor-io/risor#build-and-install-the-cli-from-source).
+</Callout>
 
 Module `k8s` provides methods for getting, listing, deleting and updating resources using the Kubernetes API.
 

--- a/modules/template/template.md
+++ b/modules/template/template.md
@@ -11,8 +11,11 @@ render(data object, template string) string
 ```
 
 Returns the rendered template as a string.
-It includes all the sprig lib functions as well as some extras like a k8sLookup function to get values from k8s objects.
+It includes all the sprig lib functions.
 You can access environment variables from the template under .Env and the passed values will be available under .Values in the template
+
+If compiled with [`-tags k8s`](https://github.com/risor-io/risor#build-and-install-the-cli-from-source),
+it also includes a k8sLookup function to get values from k8s objects.
 
 ```go filename="Example"
 >>> fetch("http://ipinfo.io").json() | render("You are in {{ .Values.city }}, region {{ .Values.region }} in {{ .Values.timezone }}")

--- a/modules/vault/vault.md
+++ b/modules/vault/vault.md
@@ -1,4 +1,11 @@
+import { Callout } from 'nextra/components';
+
 # vault
+
+<Callout type="info" emoji="ℹ️">
+  This module requires that Risor has been compiled with the `vault` Go build tag.
+  When compiling **manually**, [make sure you specify `-tags vault`](https://github.com/risor-io/risor#build-and-install-the-cli-from-source).
+</Callout>
 
 Module `vault` provides a client to interact with Hashicorp Vault
 


### PR DESCRIPTION
Based on https://github.com/risor-io/risor-site/pull/3

Adds the following note to the modules that requires extra build tag:

![image](https://github.com/risor-io/risor/assets/2477952/5d8f3418-0baf-41e9-b8f0-4849a7d28558)
