### PR TITLE
Add []string support to risor-modgen

### DIFF
--- a/cmd/risor-modgen/func.go
+++ b/cmd/risor-modgen/func.go
@@ -113,23 +113,20 @@ func (m *Module) parseFuncDeclName(decl *ast.FuncDecl) (string, error) {
 }
 
 func (m *Module) parseFuncDeclParam(name string, param *ast.Field) (FuncParam, error) {
-	switch expr := param.Type.(type) {
-	case *ast.Ident:
-		p, err := m.parseParamType(expr.Name)
-		if err != nil {
-			return FuncParam{}, err
-		}
-		p.Name = name
-		return p, nil
-	default:
-		return FuncParam{}, fmt.Errorf("unsupported parameter expression type: %T", param.Type)
+	p, err := m.parseParamType(m.sprintExpr(param.Type))
+	if err != nil {
+		return FuncParam{}, err
 	}
+	p.Name = name
+	return p, nil
 }
 
 func (m *Module) parseParamType(typeName string) (FuncParam, error) {
 	switch typeName {
 	case "string":
 		return FuncParam{ReadFunc: "AsString"}, nil
+	case "[]string":
+		return FuncParam{ReadFunc: "AsStringSlice"}, nil
 	case "bool":
 		return FuncParam{ReadFunc: "AsBool"}, nil
 	case "int64":
@@ -151,22 +148,19 @@ func (m *Module) parseParamType(typeName string) (FuncParam, error) {
 }
 
 func (m *Module) parseFuncDeclReturn(ret *ast.Field) (FuncReturn, error) {
-	switch expr := ret.Type.(type) {
-	case *ast.Ident:
-		p, err := m.parseReturnType(expr.Name)
-		if err != nil {
-			return FuncReturn{}, err
-		}
-		return p, nil
-	default:
-		return FuncReturn{}, fmt.Errorf("unsupported return expression type: %T", ret.Type)
+	p, err := m.parseReturnType(m.sprintExpr(ret.Type))
+	if err != nil {
+		return FuncReturn{}, err
 	}
+	return p, nil
 }
 
 func (m *Module) parseReturnType(typeName string) (FuncReturn, error) {
 	switch typeName {
 	case "string":
 		return FuncReturn{NewFunc: "NewString"}, nil
+	case "[]string":
+		return FuncReturn{NewFunc: "NewStringList"}, nil
 	case "bool":
 		return FuncReturn{NewFunc: "NewBool"}, nil
 	case "int64":

--- a/cmd/risor-modgen/main.go
+++ b/cmd/risor-modgen/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"crypto/sha512"
 	"flag"
 	"fmt"
 	"go/ast"
 	"go/parser"
+	"go/printer"
 	"go/token"
 	"io"
 	"io/fs"
@@ -342,6 +344,12 @@ func (m *Module) addImport(pkg string) {
 	if !slices.Contains(m.imports, pkg) {
 		m.imports = append(m.imports, pkg)
 	}
+}
+
+func (m *Module) sprintExpr(node any) string {
+	var buf bytes.Buffer
+	printer.Fprint(&buf, m.fset, node)
+	return buf.String()
 }
 
 func cutPrefixAndSpace(s, prefix string) (after string, ok bool) {

--- a/modules/strings/strings.go
+++ b/modules/strings/strings.go
@@ -1,22 +1,10 @@
 package strings
 
 import (
-	"context"
 	"strings"
-
-	"github.com/risor-io/risor/internal/arg"
-	"github.com/risor-io/risor/object"
 )
 
-//risor:generate no-module-func
-
-func asString(obj object.Object) (*object.String, *object.Error) {
-	s, ok := obj.(*object.String)
-	if !ok {
-		return nil, object.Errorf("type error: expected a string (got %v)", obj.Type())
-	}
-	return s, nil
-}
+//risor:generate
 
 //risor:export
 func contains(s, substr string) bool {
@@ -48,41 +36,19 @@ func repeat(s string, count int) string {
 	return strings.Repeat(s, count)
 }
 
-func Join(ctx context.Context, args ...object.Object) object.Object {
-	if err := arg.Require("strings.join", 2, args); err != nil {
-		return err
-	}
-	list, err := object.AsList(args[0])
-	if err != nil {
-		return err
-	}
-	sep, err := asString(args[1])
-	if err != nil {
-		return err
-	}
-	return sep.Join(list)
+//risor:export
+func join(list []string, sep string) string {
+	return strings.Join(list, sep)
 }
 
-func Split(ctx context.Context, args ...object.Object) object.Object {
-	if err := arg.Require("strings.split", 2, args); err != nil {
-		return err
-	}
-	s, err := asString(args[0])
-	if err != nil {
-		return err
-	}
-	return s.Split(args[1])
+//risor:export
+func split(s, sep string) []string {
+	return strings.Split(s, sep)
 }
 
-func Fields(ctx context.Context, args ...object.Object) object.Object {
-	if err := arg.Require("strings.fields", 1, args); err != nil {
-		return err
-	}
-	s, err := asString(args[0])
-	if err != nil {
-		return err
-	}
-	return s.Fields()
+//risor:export
+func fields(s string) []string {
+	return strings.Fields(s)
 }
 
 //risor:export
@@ -128,12 +94,4 @@ func trimSuffix(s, prefix string) string {
 //risor:export trim_space
 func trimSpace(s string) string {
 	return strings.TrimSpace(s)
-}
-
-func Module() *object.Module {
-	return object.NewBuiltinsModule("strings", addGeneratedBuiltins(map[string]object.Object{
-		"fields": object.NewBuiltin("fields", Fields),
-		"join":   object.NewBuiltin("join", Join),
-		"split":  object.NewBuiltin("split", Split),
-	}))
 }

--- a/modules/strings/strings_gen.go
+++ b/modules/strings/strings_gen.go
@@ -123,6 +123,56 @@ func Repeat(ctx context.Context, args ...object.Object) object.Object {
 	return object.NewString(result)
 }
 
+// Join is a wrapper function around [join]
+// that implements [object.BuiltinFunction].
+func Join(ctx context.Context, args ...object.Object) object.Object {
+	if len(args) != 2 {
+		return object.NewArgsError("strings.join", 2, len(args))
+	}
+	listParam, err := object.AsStringSlice(args[0])
+	if err != nil {
+		return err
+	}
+	sepParam, err := object.AsString(args[1])
+	if err != nil {
+		return err
+	}
+	result := join(listParam, sepParam)
+	return object.NewString(result)
+}
+
+// Split is a wrapper function around [split]
+// that implements [object.BuiltinFunction].
+func Split(ctx context.Context, args ...object.Object) object.Object {
+	if len(args) != 2 {
+		return object.NewArgsError("strings.split", 2, len(args))
+	}
+	sParam, err := object.AsString(args[0])
+	if err != nil {
+		return err
+	}
+	sepParam, err := object.AsString(args[1])
+	if err != nil {
+		return err
+	}
+	result := split(sParam, sepParam)
+	return object.NewStringList(result)
+}
+
+// Fields is a wrapper function around [fields]
+// that implements [object.BuiltinFunction].
+func Fields(ctx context.Context, args ...object.Object) object.Object {
+	if len(args) != 1 {
+		return object.NewArgsError("strings.fields", 1, len(args))
+	}
+	sParam, err := object.AsString(args[0])
+	if err != nil {
+		return err
+	}
+	result := fields(sParam)
+	return object.NewStringList(result)
+}
+
 // Index is a wrapper function around [index]
 // that implements [object.BuiltinFunction].
 func Index(ctx context.Context, args ...object.Object) object.Object {
@@ -287,6 +337,9 @@ func addGeneratedBuiltins(builtins map[string]object.Object) map[string]object.O
 	builtins["count"] = object.NewBuiltin("strings.count", Count)
 	builtins["compare"] = object.NewBuiltin("strings.compare", Compare)
 	builtins["repeat"] = object.NewBuiltin("strings.repeat", Repeat)
+	builtins["join"] = object.NewBuiltin("strings.join", Join)
+	builtins["split"] = object.NewBuiltin("strings.split", Split)
+	builtins["fields"] = object.NewBuiltin("strings.fields", Fields)
 	builtins["index"] = object.NewBuiltin("strings.index", Index)
 	builtins["last_index"] = object.NewBuiltin("strings.last_index", LastIndex)
 	builtins["replace_all"] = object.NewBuiltin("strings.replace_all", ReplaceAll)
@@ -299,4 +352,11 @@ func addGeneratedBuiltins(builtins map[string]object.Object) map[string]object.O
 	return builtins
 }
 
+// The "Module()" function can be disabled with "//risor:generate no-module-func"
+
+// Module returns the Risor module object with all the associated builtin
+// functions.
+func Module() *object.Module {
+	return object.NewBuiltinsModule("strings", addGeneratedBuiltins(map[string]object.Object{}))
+}
 


### PR DESCRIPTION
Don't know if this counts as cheating, but I'm just using the `go/printer` package and then switching on the result.

This means adding support for arrays `[12]byte` could be tedious, but I don't really see that happening. And if the need does come, then its easier to just add that functionality then.
