### PR TITLE
range iteration over an integer

### DIFF
--- a/examples/scripts/loop_range_int.risor
+++ b/examples/scripts/loop_range_int.risor
@@ -1,0 +1,8 @@
+
+for i := range 3 {
+    print(i)
+}
+
+for _, i := range -3 {
+    print(i)
+}

--- a/object/int.go
+++ b/object/int.go
@@ -157,6 +157,10 @@ func (i *Int) MarshalJSON() ([]byte, error) {
 	return json.Marshal(i.value)
 }
 
+func (i *Int) Iter() Iterator {
+	return NewIntIter(i)
+}
+
 func NewInt(value int64) *Int {
 	if value >= 0 && value < tableSize {
 		return intCache[value]

--- a/object/int_iter.go
+++ b/object/int_iter.go
@@ -17,7 +17,7 @@ type IntIter struct {
 }
 
 func (iter *IntIter) Type() Type {
-	return FILE_ITER
+	return INT_ITER
 }
 
 func (iter *IntIter) Inspect() string {

--- a/object/int_iter.go
+++ b/object/int_iter.go
@@ -1,0 +1,127 @@
+package object
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/risor-io/risor/op"
+)
+
+type IntIter struct {
+	*base
+	done      bool
+	target    int64
+	pos       int64
+	increment int64
+	current   *Int
+}
+
+func (iter *IntIter) Type() Type {
+	return FILE_ITER
+}
+
+func (iter *IntIter) Inspect() string {
+	return fmt.Sprintf("int_iter(%d)", iter.target)
+}
+
+func (iter *IntIter) String() string {
+	return iter.Inspect()
+}
+
+func (iter *IntIter) Interface() interface{} {
+	ctx := context.Background()
+	var entries []any
+	for {
+		entry, ok := iter.Next(ctx)
+		if !ok {
+			break
+		}
+		entries = append(entries, entry.Interface())
+	}
+	return entries
+}
+
+func (iter *IntIter) Equals(other Object) Object {
+	if iter == other {
+		return True
+	}
+	return False
+}
+
+func (iter *IntIter) GetAttr(name string) (Object, bool) {
+	switch name {
+	case "next":
+		return &Builtin{
+			name: "int_iter.next",
+			fn: func(ctx context.Context, args ...Object) Object {
+				if len(args) != 0 {
+					return NewArgsError("int_iter.next", 0, len(args))
+				}
+				value, ok := iter.Next(ctx)
+				if !ok {
+					return Nil
+				}
+				return value
+			},
+		}, true
+	case "entry":
+		return &Builtin{
+			name: "int_iter.entry",
+			fn: func(ctx context.Context, args ...Object) Object {
+				if len(args) != 0 {
+					return NewArgsError("int_iter.entry", 0, len(args))
+				}
+				entry, ok := iter.Entry()
+				if !ok {
+					return Nil
+				}
+				return entry
+			},
+		}, true
+	}
+	return nil, false
+}
+
+func (iter *IntIter) IsTruthy() bool {
+	return !iter.done
+}
+
+func (iter *IntIter) RunOperation(opType op.BinaryOpType, right Object) Object {
+	return NewError(fmt.Errorf("eval error: unsupported operation for int_iter: %v", opType))
+}
+
+func (iter *IntIter) Next(ctx context.Context) (Object, bool) {
+	if iter.done {
+		return nil, false
+	}
+	absTarget := iter.target
+	if absTarget < 0 {
+		absTarget = -absTarget
+	}
+	if iter.pos >= absTarget-1 {
+		iter.done = true
+		return nil, false
+	}
+	iter.pos++
+	iter.current = NewInt(iter.pos * iter.increment)
+	return iter.current, true
+}
+
+func (iter *IntIter) Entry() (IteratorEntry, bool) {
+	if iter.current == nil {
+		return nil, false
+	}
+	return NewEntry(NewInt(iter.pos), iter.current), true
+}
+
+func (iter *IntIter) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("type error: unable to marshal int_iter")
+}
+
+func NewIntIter(i *Int) *IntIter {
+	increment := int64(1)
+	if i.value < 0 {
+		increment = -1
+	}
+	return &IntIter{target: i.value, increment: increment, pos: -1}
+}

--- a/object/int_iter_test.go
+++ b/object/int_iter_test.go
@@ -1,0 +1,42 @@
+package object
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntIterPositive(t *testing.T) {
+	iter := NewIntIter(NewInt(3))
+	ctx := context.Background()
+	var entries []Object
+	for {
+		entry, ok := iter.Next(ctx)
+		if !ok {
+			break
+		}
+		entries = append(entries, entry)
+	}
+	require.Len(t, entries, 3)
+	require.Equal(t, NewInt(0), entries[0])
+	require.Equal(t, NewInt(1), entries[1])
+	require.Equal(t, NewInt(2), entries[2])
+}
+
+func TestIntIterNegative(t *testing.T) {
+	iter := NewIntIter(NewInt(-3))
+	ctx := context.Background()
+	var entries []Object
+	for {
+		entry, ok := iter.Next(ctx)
+		if !ok {
+			break
+		}
+		entries = append(entries, entry)
+	}
+	require.Len(t, entries, 3)
+	require.Equal(t, NewInt(0), entries[0])
+	require.Equal(t, NewInt(-1), entries[1])
+	require.Equal(t, NewInt(-2), entries[2])
+}

--- a/object/object.go
+++ b/object/object.go
@@ -52,6 +52,7 @@ const (
 	GO_METHOD     Type = "go_method"
 	GO_TYPE       Type = "go_type"
 	INT           Type = "int"
+	INT_ITER      Type = "int_iter"
 	ITER_ENTRY    Type = "iter_entry"
 	LIST          Type = "list"
 	LIST_ITER     Type = "list_iter"


### PR DESCRIPTION
This update makes `range 5` a valid expression, which evaluates to an `int_iter` object. As a result, Risor now supports the range-over-int iteration comparable to what was added in Go 1.22.

https://tip.golang.org/doc/go1.22

