### PR TITLE
add support for multiple imports in a from-import statement

### DIFF
--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -1589,6 +1589,11 @@ func TestFromImport(t *testing.T) {
 		{`from a.b import data as b_data; from a.function import plusOne; plusOne(b_data.mapValue["1"]) `, object.NewInt(2)},
 		{`from math import min; min(3,-7)`, object.NewFloat(-7)},
 		{`from math import min as m; m(3,-7)`, object.NewFloat(-7)},
+		{`from math import (min as a, max as b); [a(1,2), b(1,2)]`,
+			object.NewList([]object.Object{
+				object.NewFloat(1),
+				object.NewFloat(2),
+			})},
 	}
 	runTests(t, tests)
 }

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -1589,11 +1589,13 @@ func TestFromImport(t *testing.T) {
 		{`from a.b import data as b_data; from a.function import plusOne; plusOne(b_data.mapValue["1"]) `, object.NewInt(2)},
 		{`from math import min; min(3,-7)`, object.NewFloat(-7)},
 		{`from math import min as m; m(3,-7)`, object.NewFloat(-7)},
-		{`from math import (min as a, max as b); [a(1,2), b(1,2)]`,
+		{
+			`from math import (min as a, max as b); [a(1,2), b(1,2)]`,
 			object.NewList([]object.Object{
 				object.NewFloat(1),
 				object.NewFloat(2),
-			})},
+			}),
+		},
 	}
 	runTests(t, tests)
 }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -4,7 +4,7 @@
   "description": "Risor Language Support",
   "author": "Curtis Myzie",
   "license": "MIT",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "icon": "images/logo-256.png",
   "repository": {
     "type": "git",

--- a/vscode/syntaxes/risor.grammar.json
+++ b/vscode/syntaxes/risor.grammar.json
@@ -64,7 +64,7 @@
       "patterns": [
         {
           "name": "keyword.control.risor",
-          "match": "\\b(if|else|switch|case|default|var|const|for|func|import|return|break|continue|in|range|as|defer|struct|go)\\b"
+          "match": "\\b(if|else|switch|case|default|var|const|for|func|from|import|return|break|continue|in|range|as|defer|struct|go)\\b"
         }
       ]
     },


### PR DESCRIPTION
Updates the from-import statement to handle these variations:

```python
from math import max, min
```

```python
from math import max as a, min as b
```

```python
from math import (
    max as a,
    min
)
```