### PR TITLE
Simplify limit tracking; make limits thread-safe

### DIFF
--- a/limits/limits.go
+++ b/limits/limits.go
@@ -77,10 +77,6 @@ func NewLimitsError(message string, args ...interface{}) error {
 	return &LimitsError{message: fmt.Sprintf(message, args...)}
 }
 
-// LimitsNotFound is a standard error that indicates limits were expected to be
-// present in a context, but were not found.
-var LimitsNotFound = NewLimitsError("limit error: limits not found in context")
-
 // ReadAll reads from the given reader until EOF or the limit is reached.
 // If the given limit is less than zero, the entire reader is read.
 func ReadAll(reader io.Reader, limit int64) ([]byte, error) {

--- a/object/file.go
+++ b/object/file.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/risor-io/risor/limits"
 	"github.com/risor-io/risor/op"
 	ros "github.com/risor-io/risor/os"
 )
@@ -68,11 +67,7 @@ func (f *File) GetAttr(name string) (Object, bool) {
 				return NewArgsRangeError("file.read", 0, 1, len(args))
 			}
 			if len(args) == 0 {
-				lim, ok := limits.GetLimits(ctx)
-				if !ok {
-					return NewError(limits.LimitsNotFound)
-				}
-				bytes, err := lim.ReadAll(f.value)
+				bytes, err := io.ReadAll(f.value)
 				if err != nil {
 					return NewError(err)
 				}
@@ -97,9 +92,6 @@ func (f *File) GetAttr(name string) (Object, bool) {
 				size := stat.Size()
 				if size > math.MaxInt32 {
 					return NewError(errors.New("file.read: file size exceeds maximum int32"))
-				}
-				if err := limits.TrackCost(ctx, int(size)); err != nil {
-					return NewError(err)
 				}
 				buf := obj.Value()
 				buf.Grow(int(size)) // review: this can panic

--- a/os/localfs/localfs.go
+++ b/os/localfs/localfs.go
@@ -3,20 +3,19 @@ package localfs
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/risor-io/risor/limits"
 	ros "github.com/risor-io/risor/os"
 )
 
 var _ ros.FS = (*Filesystem)(nil)
 
 type Filesystem struct {
-	ctx    context.Context
-	base   string
-	limits limits.Limits
+	ctx  context.Context
+	base string
 }
 
 // Option is a configuration function for a local Filesystem.
@@ -32,11 +31,6 @@ func WithBase(dir string) Option {
 // New creates a new local filesystem with the given options.
 func New(ctx context.Context, opts ...Option) (*Filesystem, error) {
 	fs := &Filesystem{ctx: ctx}
-	if lim, ok := limits.GetLimits(ctx); ok {
-		fs.limits = lim
-	} else {
-		fs.limits = limits.New()
-	}
 	for _, opt := range opts {
 		opt(fs)
 	}
@@ -134,7 +128,7 @@ func (fs *Filesystem) ReadFile(name string) ([]byte, error) {
 		return nil, ros.MassagePathError(fs.base, err)
 	}
 	defer f.Close()
-	return fs.limits.ReadAll(f)
+	return io.ReadAll(f)
 }
 
 func (fs *Filesystem) Remove(name string) error {

--- a/os/s3fs/s3.go
+++ b/os/s3fs/s3.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/risor-io/risor/limits"
 	ros "github.com/risor-io/risor/os"
 )
 
@@ -138,7 +137,6 @@ type Filesystem struct {
 	ctx    context.Context
 	base   string
 	bucket string
-	limits limits.Limits
 	client *s3.Client
 }
 
@@ -169,11 +167,6 @@ func WithBucket(bucket string) Option {
 // New creates a new S3 filesystem with the given options.
 func New(ctx context.Context, opts ...Option) (*Filesystem, error) {
 	fs := &Filesystem{ctx: ctx}
-	if lim, ok := limits.GetLimits(ctx); ok {
-		fs.limits = lim
-	} else {
-		fs.limits = limits.New()
-	}
 	for _, opt := range opts {
 		opt(fs)
 	}
@@ -269,7 +262,7 @@ func (fs *Filesystem) ReadFile(name string) ([]byte, error) {
 	if err := f.get(); err != nil {
 		return nil, err
 	}
-	return fs.limits.ReadAll(f)
+	return io.ReadAll(f)
 }
 
 func (fs *Filesystem) Remove(name string) error {

--- a/os/simple.go
+++ b/os/simple.go
@@ -4,25 +4,17 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-
-	"github.com/risor-io/risor/limits"
 )
 
 var _ OS = (*SimpleOS)(nil)
 
 type SimpleOS struct {
-	ctx    context.Context
-	limits limits.Limits
-	args   []string
+	ctx  context.Context
+	args []string
 }
 
 func NewSimpleOS(ctx context.Context) *SimpleOS {
 	sos := &SimpleOS{ctx: ctx}
-	if lim, ok := limits.GetLimits(ctx); ok {
-		sos.limits = lim
-	} else {
-		sos.limits = limits.New()
-	}
 	sos.args = globalScriptargs
 	return sos
 }

--- a/os/virtual.go
+++ b/os/virtual.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/risor-io/risor/limits"
 )
 
 var _ OS = (*VirtualOS)(nil)
@@ -24,7 +23,6 @@ type Mount struct {
 
 type VirtualOS struct {
 	ctx           context.Context
-	limits        limits.Limits
 	userCacheDir  string
 	userConfigDir string
 	userHomeDir   string
@@ -155,11 +153,6 @@ func NewVirtualOS(ctx context.Context, opts ...Option) *VirtualOS {
 		cwd:    "/",
 		stdin:  &NilFile{},
 		stdout: &NilFile{},
-	}
-	if lim, ok := limits.GetLimits(ctx); ok {
-		vos.limits = lim
-	} else {
-		vos.limits = limits.New()
 	}
 	for _, opt := range opts {
 		opt(vos)
@@ -322,7 +315,7 @@ func (osObj *VirtualOS) ReadFile(name string) ([]byte, error) {
 		return nil, err
 	}
 	defer file.Close()
-	return osObj.limits.ReadAll(file)
+	return io.ReadAll(file)
 }
 
 func (osObj *VirtualOS) Remove(name string) error {

--- a/vm/options.go
+++ b/vm/options.go
@@ -2,7 +2,6 @@ package vm
 
 import (
 	"github.com/risor-io/risor/importer"
-	"github.com/risor-io/risor/limits"
 )
 
 // Option is a configuration function for a Virtual Machine.
@@ -19,13 +18,6 @@ func WithInstructionOffset(offset int) Option {
 func WithImporter(importer importer.Importer) Option {
 	return func(vm *VirtualMachine) {
 		vm.importer = importer
-	}
-}
-
-// WithLimits sets the limits for the Virtual Machine.
-func WithLimits(limits limits.Limits) Option {
-	return func(vm *VirtualMachine) {
-		vm.limits = limits
 	}
 }
 

--- a/vm/util.go
+++ b/vm/util.go
@@ -3,13 +3,8 @@ package vm
 import (
 	"fmt"
 
-	"github.com/risor-io/risor/limits"
 	"github.com/risor-io/risor/object"
 )
-
-func defaultLimits() limits.Limits {
-	return limits.New(limits.WithMaxBufferSize(100 * MB))
-}
 
 func checkCallArgs(fn *object.Function, argc int) error {
 	// Number of parameters in the function signature


### PR DESCRIPTION
The limits feature is not much used and was not implemented consistently across different built-ins. This meant it was adding complexity to the codebase without adding much value. Due to gaps in where limits were applied, a developer using Risor may have a false sense of security from it.

Given all that, I'm removing limit related behavior from much of the codebase. The limits mechanism is still available, and can be opted into by writing your own built-ins that leverage it. I did also keep the limits hookup for outgoing HTTP requests specifically, since that was fairly well defined and works.

This also updates the limits implementation to be threadsafe, which is needed now that Risor supports goroutines.