### PR TITLE
Tighten allowable cross-type comparisons

### DIFF
--- a/object/bool.go
+++ b/object/bool.go
@@ -43,11 +43,10 @@ func (b *Bool) String() string {
 }
 
 func (b *Bool) Compare(other Object) (int, error) {
-	typeComp := CompareTypes(b, other)
-	if typeComp != 0 {
-		return typeComp, nil
+	otherBool, ok := other.(*Bool)
+	if !ok {
+		return 0, fmt.Errorf("type error: unable to compare bool and %s", other.Type())
 	}
-	otherBool := other.(*Bool)
 	if b.value == otherBool.value {
 		return 0, nil
 	}

--- a/object/buffer.go
+++ b/object/buffer.go
@@ -41,7 +41,7 @@ func (b *Buffer) Compare(other Object) (int, error) {
 	case *ByteSlice:
 		return bytes.Compare(b.value.Bytes(), other.Value()), nil
 	default:
-		return 0, fmt.Errorf("type error: cannot compare buffer to type %s", other.Type())
+		return 0, fmt.Errorf("type error: unable to compare buffer and %s", other.Type())
 	}
 }
 

--- a/object/byte.go
+++ b/object/byte.go
@@ -66,7 +66,7 @@ func (b *Byte) Compare(other Object) (int, error) {
 		}
 		return -1, nil
 	default:
-		return CompareTypes(b, other), nil
+		return 0, fmt.Errorf("type error: unable to compare byte and %s", other.Type())
 	}
 }
 

--- a/object/byte_slice.go
+++ b/object/byte_slice.go
@@ -201,7 +201,7 @@ func (b *ByteSlice) Compare(other Object) (int, error) {
 	case *String:
 		return bytes.Compare(b.value, []byte(other.value)), nil
 	default:
-		return 0, fmt.Errorf("type error: cannot compare byte_slice to type %s", other.Type())
+		return 0, fmt.Errorf("type error: unable to compare byte_slice and %s", other.Type())
 	}
 }
 

--- a/object/color.go
+++ b/object/color.go
@@ -3,7 +3,6 @@ package object
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"image/color"
 
@@ -58,10 +57,6 @@ func (c *Color) Interface() interface{} {
 func (c *Color) String() string {
 	r, g, b, a := c.value.RGBA()
 	return fmt.Sprintf("color(r=%d g=%d b=%d a=%d)", r, g, b, a)
-}
-
-func (c *Color) Compare(other Object) (int, error) {
-	return 0, errors.New("type error: unable to compare colors")
 }
 
 func (c *Color) Equals(other Object) Object {

--- a/object/dir_entry.go
+++ b/object/dir_entry.go
@@ -36,10 +36,6 @@ func (d *DirEntry) String() string {
 	return fmt.Sprintf("dir_entry(%v)", d.value)
 }
 
-func (d *DirEntry) Compare(other Object) (int, error) {
-	return 0, errors.New("type error: unable to compare dir_entry objects")
-}
-
 func (d *DirEntry) Equals(other Object) Object {
 	if d == other {
 		return True

--- a/object/dynamic_attr.go
+++ b/object/dynamic_attr.go
@@ -32,10 +32,6 @@ func (d *DynamicAttr) String() string {
 	return d.Inspect()
 }
 
-func (d *DynamicAttr) Compare(other Object) (int, error) {
-	return 0, errors.New("type error: unable to compare dynamic_attr")
-}
-
 func (d *DynamicAttr) Equals(other Object) Object {
 	if d == other {
 		return True

--- a/object/error.go
+++ b/object/error.go
@@ -34,13 +34,12 @@ func (e *Error) Interface() interface{} {
 }
 
 func (e *Error) Compare(other Object) (int, error) {
-	typeComp := CompareTypes(e, other)
-	if typeComp != 0 {
-		return typeComp, nil
+	otherErr, ok := other.(*Error)
+	if !ok {
+		return 0, fmt.Errorf("type error: unable to compare error and %s", other.Type())
 	}
-	otherStr := other.(*Error)
 	thisMsg := e.Message().Value()
-	otherMsg := otherStr.Message().Value()
+	otherMsg := otherErr.Message().Value()
 	if thisMsg == otherMsg {
 		return 0, nil
 	}

--- a/object/file.go
+++ b/object/file.go
@@ -226,10 +226,6 @@ func (f *File) String() string {
 	return f.Inspect()
 }
 
-func (f *File) Compare(other Object) (int, error) {
-	return 0, errors.New("type error: unable to compare files")
-}
-
 func (f *File) Equals(other Object) Object {
 	if f == other {
 		return True

--- a/object/file_info.go
+++ b/object/file_info.go
@@ -37,10 +37,6 @@ func (f *FileInfo) String() string {
 		v.Name(), v.Mode().String(), v.Size(), v.ModTime().Format(time.RFC3339))
 }
 
-func (f *FileInfo) Compare(other Object) (int, error) {
-	return 0, errors.New("type error: unable to compare file_info objects")
-}
-
 func (f *FileInfo) Equals(other Object) Object {
 	if f == other {
 		return True

--- a/object/file_mode.go
+++ b/object/file_mode.go
@@ -51,7 +51,7 @@ func (m *FileMode) Compare(other Object) (int, error) {
 		}
 		return 0, nil
 	default:
-		return 0, fmt.Errorf("type error: unable to compare file_mode to %s", other.Type())
+		return 0, fmt.Errorf("type error: unable to compare file_mode and %s", other.Type())
 	}
 }
 

--- a/object/float.go
+++ b/object/float.go
@@ -68,7 +68,7 @@ func (f *Float) Compare(other Object) (int, error) {
 		}
 		return -1, nil
 	default:
-		return CompareTypes(f, other), nil
+		return 0, fmt.Errorf("type error: unable to compare float and %s", other.Type())
 	}
 }
 

--- a/object/float_slice.go
+++ b/object/float_slice.go
@@ -36,10 +36,6 @@ func (f *FloatSlice) String() string {
 	return f.Inspect()
 }
 
-func (f *FloatSlice) Compare(other Object) (int, error) {
-	return 0, fmt.Errorf("type error: cannot compare float_slice to type %s", other.Type())
-}
-
 func (f *FloatSlice) Equals(other Object) Object {
 	if f == other {
 		return True

--- a/object/int.go
+++ b/object/int.go
@@ -66,7 +66,7 @@ func (i *Int) Compare(other Object) (int, error) {
 		}
 		return -1, nil
 	default:
-		return CompareTypes(i, other), nil
+		return 0, fmt.Errorf("type error: unable to compare int and %s", other.Type())
 	}
 }
 

--- a/object/list.go
+++ b/object/list.go
@@ -427,14 +427,13 @@ func (ls *List) String() string {
 }
 
 func (ls *List) Compare(other Object) (int, error) {
-	typeComp := CompareTypes(ls, other)
-	if typeComp != 0 {
-		return typeComp, nil
+	otherList, ok := other.(*List)
+	if !ok {
+		return 0, fmt.Errorf("type error: unable to compare list and %s", other.Type())
 	}
-	otherArr := other.(*List)
-	if len(ls.items) > len(otherArr.items) {
+	if len(ls.items) > len(otherList.items) {
 		return 1, nil
-	} else if len(ls.items) < len(otherArr.items) {
+	} else if len(ls.items) < len(otherList.items) {
 		return -1, nil
 	}
 	for i := 0; i < len(ls.items); i++ {
@@ -443,7 +442,7 @@ func (ls *List) Compare(other Object) (int, error) {
 			return 0, fmt.Errorf("type error: %s object is not comparable",
 				ls.items[i].Type())
 		}
-		comp, err := comparable.Compare(otherArr.items[i])
+		comp, err := comparable.Compare(otherList.items[i])
 		if err != nil {
 			return 0, err
 		}

--- a/object/module.go
+++ b/object/module.go
@@ -89,11 +89,10 @@ func (m *Module) Code() *compiler.Code {
 }
 
 func (m *Module) Compare(other Object) (int, error) {
-	typeComp := CompareTypes(m, other)
-	if typeComp != 0 {
-		return typeComp, nil
+	otherMod, ok := other.(*Module)
+	if !ok {
+		return 0, fmt.Errorf("type error: unable to compare module and %s", other.Type())
 	}
-	otherMod := other.(*Module)
 	if m.name == otherMod.name {
 		return 0, nil
 	}

--- a/object/nil.go
+++ b/object/nil.go
@@ -31,7 +31,10 @@ func (n *NilType) HashKey() HashKey {
 }
 
 func (n *NilType) Compare(other Object) (int, error) {
-	return CompareTypes(n, other), nil
+	if _, ok := other.(*NilType); ok {
+		return 0, nil
+	}
+	return 0, fmt.Errorf("type error: unable to compare nil and %s", other.Type())
 }
 
 func (n *NilType) Equals(other Object) Object {

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestObjectString(t *testing.T) {
@@ -34,5 +36,63 @@ func TestObjectString(t *testing.T) {
 		if str.String() != tt.expected {
 			t.Errorf("object.String() wrong. want=%q, got=%q", tt.expected, str.String())
 		}
+	}
+}
+
+func TestComparisons(t *testing.T) {
+	tests := []struct {
+		left        Object
+		right       Object
+		expected    int
+		expectedErr error
+	}{
+		{NewInt(1), NewInt(1), 0, nil},
+		{NewInt(1), NewInt(2), -1, nil},
+		{NewInt(2), NewInt(1), 1, nil},
+		{NewFloat(1.0), NewFloat(1.0), 0, nil},
+		{NewFloat(1.0), NewFloat(2.0), -1, nil},
+		{NewFloat(2.0), NewFloat(1.0), 1, nil},
+		{NewString("a"), NewString("a"), 0, nil},
+		{NewString("a"), NewString("b"), -1, nil},
+		{NewString("b"), NewString("a"), 1, nil},
+		{True, True, 0, nil},
+		{True, False, 1, nil},
+		{False, True, -1, nil},
+		{Nil, Nil, 0, nil},
+		{Nil, True, 0, errors.New("type error: unable to compare nil and bool")},
+		{NewInt(1), NewFloat(1.0), 0, nil},
+		{NewInt(1), NewFloat(2.0), -1, nil},
+		{NewInt(1), NewFloat(0.0), 1, nil},
+		{NewFloat(1.0), NewInt(1), 0, nil},
+		{NewFloat(1.0), NewInt(2), -1, nil},
+		{NewFloat(1.0), NewInt(0), 1, nil},
+		{NewInt(1), NewString("1"), 0, errors.New("type error: unable to compare int and string")},
+		{NewString("1"), NewInt(1), 0, errors.New("type error: unable to compare string and int")},
+		{NewFloat(1.0), NewString("1"), 0, errors.New("type error: unable to compare float and string")},
+		{NewString("1"), NewFloat(1.0), 0, errors.New("type error: unable to compare string and float")},
+		{NewByte(1), NewByte(1), 0, nil},
+		{NewByte(1), NewByte(2), -1, nil},
+		{NewByte(2), NewByte(1), 1, nil},
+		{NewByte(1), NewInt(1), 0, nil},
+		{NewByte(1), NewInt(2), -1, nil},
+		{NewByte(2), NewInt(1), 1, nil},
+		{NewInt(1), NewByte(1), 0, nil},
+		{NewInt(1), NewByte(2), -1, nil},
+		{NewInt(2), NewByte(1), 1, nil},
+		{NewByte(1), NewFloat(1.0), 0, nil},
+		{NewByte(1), NewFloat(2.0), -1, nil},
+		{NewByte(2), NewFloat(1.0), 1, nil},
+		{NewFloat(1.0), NewByte(1), 0, nil},
+		{NewFloat(1.0), NewByte(2), -1, nil},
+		{NewFloat(1.0), NewByte(0), 1, nil},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s %s", tt.left.Type(), tt.right.Type()), func(t *testing.T) {
+			comparable, ok := tt.left.(Comparable)
+			require.True(t, ok)
+			cmp, cmpErr := comparable.Compare(tt.right)
+			require.Equal(t, tt.expected, cmp)
+			require.Equal(t, tt.expectedErr, cmpErr)
+		})
 	}
 }

--- a/object/string.go
+++ b/object/string.go
@@ -213,11 +213,10 @@ func (s *String) Interface() interface{} {
 }
 
 func (s *String) Compare(other Object) (int, error) {
-	typeComp := CompareTypes(s, other)
-	if typeComp != 0 {
-		return typeComp, nil
+	otherStr, ok := other.(*String)
+	if !ok {
+		return 0, fmt.Errorf("type error: unable to compare string and %s", other.Type())
 	}
-	otherStr := other.(*String)
 	if s.value == otherStr.value {
 		return 0, nil
 	}

--- a/object/time.go
+++ b/object/time.go
@@ -52,11 +52,10 @@ func (t *Time) String() string {
 }
 
 func (t *Time) Compare(other Object) (int, error) {
-	typeComp := CompareTypes(t, other)
-	if typeComp != 0 {
-		return typeComp, nil
+	otherStr, ok := other.(*Time)
+	if !ok {
+		return 0, fmt.Errorf("type error: unable to compare time and %s", other.Type())
 	}
-	otherStr := other.(*Time)
 	if t.value == otherStr.value {
 		return 0, nil
 	}

--- a/tests/test-2022-11-28-10-29.tm
+++ b/tests/test-2022-11-28-10-29.tm
@@ -1,8 +1,8 @@
-// expected value: [1, 2, 2.2, 3, "a"]
+// expected value: [1, 2, 2.2, 3]
 // expected type: list
 
-s1 := {1, "a", 2.2}
-s2 := {2, "a", 2.2}
+s1 := {1, 2.2}
+s2 := {2, 2.2}
 
 s1.add(3)
 


### PR DESCRIPTION
Fixes https://github.com/risor-io/risor/issues/216

All numeric types are comparable with each other.

Numerics can't be compared with strings.

Don't implement Compare for types that don't support any comparisons.