### PR TITLE
Allow newlines after operators in infix expressions

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -831,6 +831,11 @@ func (p *Parser) parseInfixExpr(leftNode ast.Node) ast.Node {
 	firstToken := p.curToken
 	precedence := p.currentPrecedence()
 	p.nextToken()
+	for p.curTokenIs(token.NEWLINE) {
+		if err := p.nextToken(); err != nil {
+			return nil
+		}
+	}
 	right := p.parseExpression(precedence)
 	if right == nil {
 		p.setTokenError(p.curToken, "invalid expression")

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1102,3 +1102,22 @@ func TestInvalidListTermination(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, `parse error: invalid syntax (unexpected "}")`, err.Error())
 }
+
+func TestMultilineInfixExprs(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"1 +\n2", "(1 + 2)"},
+		{"1 +\n2 /\n3", "(1 + (2 / 3))"},
+		{"false || \n\n\ntrue", "(false || true)"},
+		{"true &&\n \nfalse", "(true && false)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result, err := Parse(context.Background(), tt.input)
+			require.Nil(t, err)
+			require.Equal(t, tt.expected, result.String())
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/risor-io/risor/issues/218