### PR TITLE
fix stack pollution with defers

### DIFF
--- a/vm/vm.go
+++ b/vm/vm.go
@@ -746,6 +746,10 @@ func (vm *VirtualMachine) callFunction(
 			if err := vm.callObject(ctx, partial.Function(), partial.Args()); err != nil {
 				result = nil
 				resultErr = err
+			} else {
+				// Discard the result of the deferred function call, which is
+				// guaranteed to have pushed a single value onto the stack.
+				vm.pop()
 			}
 		}
 	}()
@@ -758,7 +762,8 @@ func (vm *VirtualMachine) callFunction(
 }
 
 // Call a callable object with the given arguments. Returns an error if the
-// object is not callable.
+// object is not callable. If this call succeeds, the result of the call will
+// have been pushed onto the stack.
 func (vm *VirtualMachine) callObject(
 	ctx context.Context,
 	fn object.Object,

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -1766,6 +1766,28 @@ func TestDeferBehavior(t *testing.T) {
 	}), result)
 }
 
+func TestDeferNoStackPollution(t *testing.T) {
+	code := `
+	result := []
+	func append_value(v) {
+		defer func(v) {
+			result.append(v)
+		}(v)
+	}
+	for _, v := range [1, 2, 3] {
+		append_value(v)
+	}
+	result
+	`
+	result, err := run(context.Background(), code)
+	require.Nil(t, err)
+	require.Equal(t, object.NewList([]object.Object{
+		object.NewInt(1),
+		object.NewInt(2),
+		object.NewInt(3),
+	}), result)
+}
+
 func TestFreeVariables(t *testing.T) {
 	code := `
 	func test(count) {


### PR DESCRIPTION
A successful deferred function call pushes the result onto the VM stack. This was not being popped off before, which causes a problem when the deferred is executing within a loop and probably other situations too. We just need to pop this value to ignore it.