### PR TITLE
Fix handling of cli vs script arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ docker-build:
 	docker buildx build \
 		-t risor/risor:latest \
 		-t risor/risor:$(GIT_REVISION) \
+		-t risor/risor:1.5.2 \
 		--build-arg "RISOR_VERSION=1.5.2" \
 		--build-arg "GIT_REVISION=$(GIT_REVISION)" \
 		--build-arg "BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')" \

--- a/cmd/risor/options.go
+++ b/cmd/risor/options.go
@@ -95,9 +95,16 @@ func getRisorOptions() []risor.Option {
 }
 
 func shouldRunRepl(cmd *cobra.Command, args []string) bool {
-	codeFlagSupplied := cmd.Flags().Lookup("code").Changed
-	noInputCode := len(args) == 0 && !codeFlagSupplied && !viper.GetBool("stdin")
-	return noInputCode && isTerminalIO()
+	if viper.GetBool("no-repl") || viper.GetBool("stdin") {
+		return false
+	}
+	if cmd.Flags().Lookup("code").Changed {
+		return false
+	}
+	if len(args) > 0 {
+		return false
+	}
+	return isTerminalIO()
 }
 
 func getRisorCode(cmd *cobra.Command, args []string) (string, error) {

--- a/cmd/risor/root.go
+++ b/cmd/risor/root.go
@@ -52,6 +52,7 @@ func init() {
 	// Root command flags
 	rootCmd.Flags().Bool("timing", false, "Show timing information")
 	rootCmd.Flags().StringP("output", "o", "", "Set the output format")
+	rootCmd.Flags().Bool("no-repl", false, "Disable the REPL")
 	rootCmd.RegisterFlagCompletionFunc("output",
 		cobra.FixedCompletions(
 			outputFormatsCompletion,
@@ -61,6 +62,7 @@ func init() {
 
 	viper.BindPFlag("timing", rootCmd.Flags().Lookup("timing"))
 	viper.BindPFlag("output", rootCmd.Flags().Lookup("output"))
+	viper.BindPFlag("no-repl", rootCmd.Flags().Lookup("no-repl"))
 
 	viper.AutomaticEnv()
 }
@@ -133,7 +135,7 @@ var rootCmd = &cobra.Command{
 		// Separate arguments belonging to the Risor CLI from those that are
 		// to be passed to the script.
 		var scriptArgs []string
-		args, scriptArgs, _ = getScriptArgs(args)
+		args, scriptArgs = getScriptArgs(args)
 		ros.SetScriptArgs(scriptArgs)
 
 		// Optional virtual operating system with filesystem mounts.

--- a/cmd/risor/util_test.go
+++ b/cmd/risor/util_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestGetScriptArguments(t *testing.T) {
-
-	var test = []struct {
+	test := []struct {
 		args      []string
 		expOS     []string
 		expScript []string

--- a/cmd/risor/util_test.go
+++ b/cmd/risor/util_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetScriptArguments(t *testing.T) {
+
+	var test = []struct {
+		args      []string
+		expOS     []string
+		expScript []string
+	}{
+		{
+			[]string{"--foo", "--bar", "1"},
+			[]string{"--foo", "--bar", "1"},
+			[]string{},
+		},
+		{
+			[]string{"--foo", "1", "--", "/path/to/script"},
+			[]string{"/path/to/script"},
+			[]string{"/path/to/script"},
+		},
+		{
+			[]string{"--foo", "1", "--"},
+			[]string{},
+			[]string{},
+		},
+		{
+			[]string{"--", "/path/to/script", "2", "-h", "--bar"},
+			[]string{"/path/to/script"},
+			[]string{"/path/to/script", "2", "-h", "--bar"},
+		},
+		{
+			[]string{"--"},
+			[]string{},
+			[]string{},
+		},
+		{
+			[]string{},
+			[]string{},
+			[]string{},
+		},
+		{
+			[]string{"--no-repl", "1", "--", "/path/to/script", "1", "-f"},
+			[]string{"/path/to/script"},
+			[]string{"/path/to/script", "1", "-f"},
+		},
+	}
+
+	for _, tt := range test {
+		t.Run(strings.Join(tt.args, "-"), func(t *testing.T) {
+			origArgs := os.Args
+			testArgs := []string{"risor"}
+			testArgs = append(testArgs, tt.args...)
+			os.Args = testArgs
+			defer func() { os.Args = origArgs }()
+			osArgs, scriptArgs := getScriptArgs(tt.args)
+			require.Equal(t, tt.expOS, osArgs)
+			require.Equal(t, tt.expScript, scriptArgs)
+		})
+	}
+}

--- a/examples/scripts/channels.risor
+++ b/examples/scripts/channels.risor
@@ -1,3 +1,4 @@
+#!/usr/bin/env risor --
 
 // Return a channel that will be used to send random values
 func work(count) {

--- a/examples/scripts/gha.risor
+++ b/examples/scripts/gha.risor
@@ -1,4 +1,4 @@
-#!/usr/bin/env risor
+#!/usr/bin/env risor --
 
 // Using the gh module requires that Risor is built with `-tags gh`
 

--- a/examples/scripts/http_server.risor
+++ b/examples/scripts/http_server.risor
@@ -1,3 +1,4 @@
+#!/usr/bin/env risor --
 
 http.handle("/", func(w, r) {
     return "OK"

--- a/examples/scripts/loop_range_int.risor
+++ b/examples/scripts/loop_range_int.risor
@@ -1,3 +1,4 @@
+#!/usr/bin/env risor --
 
 for i := range 3 {
     print(i)

--- a/examples/scripts/spawn.risor
+++ b/examples/scripts/spawn.risor
@@ -1,3 +1,4 @@
+#!/usr/bin/env risor --
 
 func work(x) {
     return x ** 2

--- a/examples/scripts/spawn_func.risor
+++ b/examples/scripts/spawn_func.risor
@@ -1,3 +1,4 @@
+#!/usr/bin/env risor --
 
 values := [3, 1, 4, 2, 5]
 

--- a/modules/cli/cli.go
+++ b/modules/cli/cli.go
@@ -39,6 +39,7 @@ func FlagFunc(ctx context.Context, args ...object.Object) object.Object {
 	var flag *Flag
 	flagValue, hasFlagValue := opts["value"]
 	if typ, ok := opts["type"]; ok {
+		delete(opts, "type")
 		typStr, ok := typ.(*object.String)
 		if !ok {
 			return object.Errorf("cli.flag type expected string (got %s)", typ.Type())


### PR DESCRIPTION
Fixes relating to splitting arguments: some for the Risor CLI, some for the Risor script. Separated using `--`.

Cobra CLI contributes to making this really tricky.