### PR TITLE
Fix edge case with compiling loops containing undefined variables

### DIFF
--- a/compiler/code.go
+++ b/compiler/code.go
@@ -8,8 +8,14 @@ import (
 )
 
 type loop struct {
+	code        *Code
 	continuePos []int
 	breakPos    []int
+}
+
+func (l *loop) end() {
+	code := l.code
+	code.loops = code.loops[:len(code.loops)-1]
 }
 
 type Code struct {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -298,15 +298,10 @@ func (c *Compiler) compile(node ast.Node) error {
 // startLoop should be called when starting to compile a new loop. This is used
 // to understand which loop that "break" and "continue" statements should target.
 func (c *Compiler) startLoop() *loop {
-	loop := &loop{}
-	c.current.loops = append(c.current.loops, loop)
+	currentCode := c.current
+	loop := &loop{code: currentCode}
+	currentCode.loops = append(currentCode.loops, loop)
 	return loop
-}
-
-// endLoop should be called when the compilation of a loop is done.
-func (c *Compiler) endLoop() {
-	code := c.current
-	code.loops = code.loops[:len(code.loops)-1]
 }
 
 // currentLoop returns the loop that is currently being compiled, which is the
@@ -1284,7 +1279,7 @@ func (c *Compiler) compileForRange(forNode *ast.For, names []string, container a
 	code.symbols = code.symbols.NewBlock()
 	loop := c.startLoop()
 	defer func() {
-		c.endLoop()
+		loop.end()
 		code.symbols = code.symbols.parent
 	}()
 
@@ -1348,7 +1343,7 @@ func (c *Compiler) compileForCondition(forNode *ast.For, condition ast.Expressio
 	code.symbols = code.symbols.NewBlock()
 	loop := c.startLoop()
 	defer func() {
-		c.endLoop()
+		loop.end()
 		code.symbols = code.symbols.parent
 	}()
 	startPos := c.currentPosition()
@@ -1429,7 +1424,7 @@ func (c *Compiler) compileFor(node *ast.For) error {
 	code.symbols = code.symbols.NewBlock()
 	loop := c.startLoop()
 	defer func() {
-		c.endLoop()
+		loop.end()
 		code.symbols = code.symbols.parent
 	}()
 
@@ -1516,7 +1511,7 @@ func (c *Compiler) compileSimpleFor(node *ast.For) error {
 	code.symbols = code.symbols.NewBlock()
 	loop := c.startLoop()
 	defer func() {
-		c.endLoop()
+		loop.end()
 		code.symbols = code.symbols.parent
 	}()
 	startPos := c.currentPosition()

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -72,3 +72,20 @@ func TestCompileErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestCompilerLoopError(t *testing.T) {
+	input := `
+for _, v := range [1, 2, 3] {
+	func() {
+		undefined_var
+	}()
+}
+	`
+	c, err := New()
+	require.Nil(t, err)
+	ast, err := parser.Parse(context.Background(), input)
+	require.Nil(t, err)
+	_, err = c.Compile(ast)
+	require.NotNil(t, err)
+	require.Equal(t, "compile error: undefined variable \"undefined_var\" (line 4)", err.Error())
+}

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -33,8 +33,9 @@ func TestObjectString(t *testing.T) {
 			t.Errorf("object.String() not implemented for %T", tt.input)
 			continue
 		}
-		if str.String() != tt.expected {
-			t.Errorf("object.String() wrong. want=%q, got=%q", tt.expected, str.String())
+		result := str.String()
+		if result != tt.expected {
+			t.Errorf("object.String() wrong. want=%q, got=%q", tt.expected, result)
 		}
 	}
 }

--- a/object/set.go
+++ b/object/set.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/risor-io/risor/op"
@@ -121,7 +122,23 @@ func (s *Set) SortedItems() []Object {
 	for _, v := range s.items {
 		items = append(items, v)
 	}
-	Sort(items)
+	sort.Slice(items, func(i, j int) bool {
+		h1 := items[i].(Hashable).HashKey()
+		h2 := items[j].(Hashable).HashKey()
+		if h1.Type != h2.Type {
+			return h1.Type < h2.Type
+		}
+		if h1.IntValue != h2.IntValue {
+			return h1.IntValue < h2.IntValue
+		}
+		if h1.StrValue != h2.StrValue {
+			return h1.StrValue < h2.StrValue
+		}
+		if h1.FltValue != h2.FltValue {
+			return h1.FltValue < h2.FltValue
+		}
+		return false
+	})
 	return items
 }
 


### PR DESCRIPTION
Capture the code the loop is associated with so we can correctly close it out, when there is a compile error.