### PR TITLE
fix typo in cli docs

### DIFF
--- a/modules/cli/cli.md
+++ b/modules/cli/cli.md
@@ -30,7 +30,7 @@ app({
     name: "myapp",
     description: "My app description",
     commands: [
-        command({
+        c({
             name: "hello",
             description: "Say hello",
             action: func(ctx) {


### PR DESCRIPTION
compile error: undefined variable "command" (line 7)
