### PR TITLE
Adjust some parser edge cases

### DIFF
--- a/ast/statements.go
+++ b/ast/statements.go
@@ -179,7 +179,7 @@ func (c *Control) String() string {
 	var out bytes.Buffer
 	out.WriteString(c.Literal())
 	if c.value != nil {
-		out.WriteString(" " + c.value.Literal())
+		out.WriteString(" " + c.value.String())
 	}
 	return out.String()
 }
@@ -212,7 +212,7 @@ func (r *Return) String() string {
 	var out bytes.Buffer
 	out.WriteString(r.Literal())
 	if r.value != nil {
-		out.WriteString(" " + r.value.Literal())
+		out.WriteString(" " + r.value.String())
 	}
 	return out.String()
 }

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -130,7 +130,7 @@ func (c *Compiler) Compile(node ast.Node) (*Code, error) {
 func (c *Compiler) compile(node ast.Node) error {
 	switch node := node.(type) {
 	case *ast.Nil:
-		if err := c.compileNil(node); err != nil {
+		if err := c.compileNil(); err != nil {
 			return err
 		}
 	case *ast.Int:
@@ -318,7 +318,7 @@ func (c *Compiler) currentPosition() int {
 	return len(c.current.instructions)
 }
 
-func (c *Compiler) compileNil(node *ast.Nil) error {
+func (c *Compiler) compileNil() error {
 	c.emit(op.Nil)
 	return nil
 }
@@ -1412,10 +1412,10 @@ func (c *Compiler) compileFor(node *ast.For) error {
 			}
 		case *ast.Range:
 			return c.compileForRange(node, nil, cond.Container())
-		case *ast.Infix:
+		case ast.Expression:
 			return c.compileForCondition(node, cond)
 		default:
-			return c.compileForRange(node, nil, cond)
+			return fmt.Errorf("compile error: invalid for loop")
 		}
 	}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -278,26 +278,34 @@ func (p *Parser) setError(err ParserError) {
 }
 
 func (p *Parser) parseStatement() ast.Node {
+	var stmt ast.Node
 	switch p.curToken.Type {
 	case token.VAR:
-		return p.parseVar()
+		stmt = p.parseVar()
 	case token.CONST:
-		return p.parseConst()
+		stmt = p.parseConst()
 	case token.RETURN:
-		return p.parseReturn()
+		stmt = p.parseReturn()
 	case token.BREAK:
-		return p.parseBreak()
+		stmt = p.parseBreak()
 	case token.CONTINUE:
-		return p.parseContinue()
+		stmt = p.parseContinue()
 	case token.NEWLINE:
 		return nil
 	case token.IDENT:
 		if p.peekTokenIs(token.DECLARE) || p.peekTokenIs(token.COMMA) {
-			return p.parseDeclaration()
+			stmt = p.parseDeclaration()
+		} else {
+			stmt = p.parseExpressionStatement()
 		}
-		// intentional fallthrough!
+	default:
+		stmt = p.parseExpressionStatement()
 	}
-	return p.parseExpressionStatement()
+	// Consume trailing semicolon if present
+	if p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+	}
+	return stmt
 }
 
 func (p *Parser) parseVar() ast.Node {
@@ -930,62 +938,112 @@ func (p *Parser) parseIf() ast.Node {
 
 func (p *Parser) parseFor() ast.Node {
 	forToken := p.curToken
+	p.nextToken() // Move past 'for'
+
 	// Check for simple form: "for { ... }"
-	if p.peekTokenIs(token.LBRACE) {
-		p.nextToken()
+	if p.curTokenIs(token.LBRACE) {
 		consequence := p.parseBlock()
 		if consequence == nil {
 			return nil
 		}
 		return ast.NewSimpleFor(forToken, consequence)
 	}
-	p.nextToken()
-	forExprToken := p.curToken
-	firstExpr := p.parseStatement()
-	if firstExpr == nil {
-		p.setTokenError(forExprToken, "invalid for loop expression")
-		p.nextToken()
-		return nil
+
+	// Parse the initialization or condition
+	var init, condition, post ast.Node
+	if !p.curTokenIs(token.SEMICOLON) {
+		init = p.parseStatement()
+		if init == nil {
+			p.setTokenError(p.curToken, "invalid for loop initialization or condition")
+			return nil
+		}
 	}
-	// Check for while loop form: "for condition { ... }"
+
+	// Check for condition-only form: "for condition { ... }"
+	fmt.Println("INIT", init, "CURTOKEN:", p.curToken.Literal)
 	if p.peekTokenIs(token.LBRACE) {
 		p.nextToken()
 		consequence := p.parseBlock()
 		if consequence == nil {
 			return nil
 		}
-		return ast.NewFor(forToken, firstExpr, consequence, nil, nil)
+		return ast.NewFor(forToken, init, consequence, nil, nil)
 	}
+
+	// Check if the init statement is a range statement
+	var isRangeLoop bool
+	switch initNode := init.(type) {
+	case *ast.Var:
+		_, expr := initNode.Value()
+		if _, ok := expr.(*ast.Range); ok {
+			isRangeLoop = true
+		}
+	case *ast.MultiVar:
+		_, expr := initNode.Value()
+		if _, ok := expr.(*ast.Range); ok {
+			isRangeLoop = true
+		}
+	}
+
+	if isRangeLoop {
+		// This is a range-based for loop
+		if !p.expectPeek("for range loop", token.LBRACE) {
+			return nil
+		}
+		consequence := p.parseBlock()
+		if consequence == nil {
+			return nil
+		}
+		// Use the init node (which contains the range expression) as the condition
+		return ast.NewFor(forToken, init, consequence, nil, nil)
+	}
+
+	// If we've reached here, we're dealing with a three-part for loop
 	if !p.curTokenIs(token.SEMICOLON) {
-		p.setTokenError(p.curToken, "expected a semicolon (got %s)", p.curToken.Literal)
+		p.setTokenError(p.curToken, "expected semicolon after for loop initialization")
 		return nil
 	}
-	p.nextToken() // move past the ";"
-	condition := p.parseNode(LOWEST)
+	p.nextToken() // Move past the first semicolon
+
+	// Parse the condition
+	if !p.curTokenIs(token.SEMICOLON) {
+		condition = p.parseExpression(LOWEST)
+		if condition == nil {
+			p.setTokenError(p.curToken, "invalid for loop condition")
+			return nil
+		}
+	}
 	if !p.expectPeek("for loop", token.SEMICOLON) {
 		return nil
 	}
-	if !p.expectPeek("for loop", token.IDENT) {
-		return nil
+	p.nextToken() // Move past the second semicolon
+
+	// Parse the post statement
+	if !p.curTokenIs(token.LBRACE) {
+		if p.curTokenIs(token.IDENT) && (p.peekTokenIs(token.PLUS_PLUS) || p.peekTokenIs(token.MINUS_MINUS)) {
+			identToken := p.curToken
+			p.nextToken()
+			post = ast.NewPostfix(identToken, p.curToken.Literal)
+		} else {
+			post = p.parseStatement()
+		}
+		if post == nil {
+			p.setTokenError(p.curToken, "invalid for loop post statement")
+			return nil
+		}
 	}
-	var postExpr ast.Node
-	if p.peekTokenIs(token.PLUS_PLUS) || p.peekTokenIs(token.MINUS_MINUS) {
-		p.nextToken()
-		postExpr = p.parsePostfix()
-	} else {
-		postExpr = p.parseNode(LOWEST)
-	}
-	if postExpr == nil {
-		return nil
-	}
+
+	// Expect the opening brace of the loop body
 	if !p.expectPeek("for loop", token.LBRACE) {
 		return nil
 	}
+
 	consequence := p.parseBlock()
 	if consequence == nil {
 		return nil
 	}
-	return ast.NewFor(forToken, condition, consequence, firstExpr, postExpr)
+
+	return ast.NewFor(forToken, condition, consequence, init, post)
 }
 
 func (p *Parser) parseBlock() *ast.Block {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -208,15 +208,15 @@ func TestForRange7(t *testing.T) {
 
 func TestIterator(t *testing.T) {
 	tests := []testCase{
-		{`(range { 33, 44, 55 }).next()`, object.NewInt(33)},
-		{`i := range { 33, 44, 55 }; i.next(); i.entry().value`, object.True},
-		{`i := range { 33, 44, 55 }; i.next(); i.entry().key`, object.NewInt(33)},
+		{`(range [ 33, 44, 55 ]).next()`, object.NewInt(33)},
+		{`c := { 33, 44, 55 }; i := range c; i.next(); i.entry().value`, object.True},
+		{`c := { 33, 44, 55 }; i := range c; i.next(); i.entry().key`, object.NewInt(33)},
 		{`(range [ 33, 44, 55 ]).next()`, object.NewInt(33)},
 		{`i := range "abcd"; i.next(); i.entry().key`, object.NewInt(0)},
 		{`i := range "abcd"; i.next(); i.entry().value`, object.NewString("a")},
-		{`(range { a: 33, b: 44 }).next()`, object.NewString("a")},
-		{`i := range { a: 33, b: 44 }; i.next(); i.entry().key`, object.NewString("a")},
-		{`i := range { a: 33, b: 44 }; i.next(); i.entry().value`, object.NewInt(33)},
+		{`c := { a: 33, b: 44 }; (range c).next()`, object.NewString("a")},
+		{`c := { a: 33, b: 44 }; i := range c; i.next(); i.entry().key`, object.NewString("a")},
+		{`c := { a: 33, b: 44 }; i := range c; i.next(); i.entry().value`, object.NewInt(33)},
 	}
 	runTests(t, tests)
 }
@@ -1137,13 +1137,13 @@ func TestForExprCondition(t *testing.T) {
 }
 
 func TestInvalidForCondition(t *testing.T) {
-	_, err := run(context.Background(), `
+	result, err := run(context.Background(), `
 	count := 10
-	for count := 0 { count-- }
+	for x := 2 { count-- }
 	count
 	`)
-	require.Error(t, err)
-	require.Equal(t, err.Error(), "compile error: invalid condition in for loop")
+	require.NoError(t, err)
+	require.Equal(t, object.NewInt(8), result)
 }
 
 func TestSimpleLoopBreak(t *testing.T) {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -185,17 +185,6 @@ func TestForRange5(t *testing.T) {
 	require.Equal(t, object.NewInt(3), result)
 }
 
-func TestForRange6(t *testing.T) {
-	result, err := run(context.Background(), `
-	x := 0
-	r := range { "a", "b" }
-	for r { x++ }
-	x
-	`)
-	require.Nil(t, err)
-	require.Equal(t, object.NewInt(2), result)
-}
-
 func TestForRange7(t *testing.T) {
 	result, err := run(context.Background(), `
 	x := nil
@@ -1109,6 +1098,32 @@ func TestRangeLoopContinue(t *testing.T) {
 	`)
 	require.Nil(t, err)
 	require.Equal(t, object.NewInt(3), result)
+}
+
+func TestForCondition(t *testing.T) {
+	result, err := run(context.Background(), `
+	c := true
+	count := 0
+	for c {
+		count++
+		if count == 10 {
+			c = false
+		}
+	}
+	count
+	`)
+	require.Nil(t, err)
+	require.Equal(t, object.NewInt(10), result)
+}
+
+func TestForIntCondition(t *testing.T) {
+	result, err := run(context.Background(), `
+	count := 10
+	for count { count-- }
+	count
+	`)
+	require.Nil(t, err)
+	require.Equal(t, object.NewInt(0), result)
 }
 
 func TestSimpleLoopBreak(t *testing.T) {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -1126,6 +1126,16 @@ func TestForIntCondition(t *testing.T) {
 	require.Equal(t, object.NewInt(0), result)
 }
 
+func TestForExprCondition(t *testing.T) {
+	result, err := run(context.Background(), `
+	count := 10
+	for (count >= 5) { count-- }
+	count
+	`)
+	require.Nil(t, err)
+	require.Equal(t, object.NewInt(4), result)
+}
+
 func TestSimpleLoopBreak(t *testing.T) {
 	result, err := run(context.Background(), `
 	x := 0

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -1136,6 +1136,16 @@ func TestForExprCondition(t *testing.T) {
 	require.Equal(t, object.NewInt(4), result)
 }
 
+func TestInvalidForCondition(t *testing.T) {
+	_, err := run(context.Background(), `
+	count := 10
+	for count := 0 { count-- }
+	count
+	`)
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "compile error: invalid condition in for loop")
+}
+
 func TestSimpleLoopBreak(t *testing.T) {
 	result, err := run(context.Background(), `
 	x := 0


### PR DESCRIPTION
Fixes https://github.com/risor-io/risor/issues/254
Fixes https://github.com/risor-io/risor/issues/243

Changes include:
- Fix printing of ast.Control and ast.Return objects
- Allow arbitrary "post" statements in for loop definitions
- Disallow multiple statements per line that are not separated by a `;`
- Disallow range statements over set or map literals, since they begin with the `{` token. This eliminates a class of confusing parse/compile errors that were previously possible.