### PR TITLE
Add new form for executing subcommands using exec (backwards compatible)

### DIFF
--- a/modules/exec/exec.go
+++ b/modules/exec/exec.go
@@ -15,11 +15,31 @@ func CommandFunc(ctx context.Context, args ...object.Object) object.Object {
 	if err := arg.RequireRange("command", 1, 1000, args); err != nil {
 		return err
 	}
+	var strArgs []string
+	// Two forms of arguments are supported:
+	// 1. command(["ls", "-l"]) - this is the newly added form
+	// 2. command("ls", "-l") - this is the original form
+	if len(args) == 1 {
+		if list, err := object.AsList(args[0]); err == nil {
+			// This is form 1
+			for _, arg := range list.Value() {
+				argStr, err := object.AsString(arg)
+				if err != nil {
+					return err
+				}
+				strArgs = append(strArgs, argStr)
+			}
+			if len(strArgs) == 0 {
+				return object.Errorf("exec.command expected at least one argument in list")
+			}
+			return NewCommand(exec.CommandContext(ctx, strArgs[0], strArgs[1:]...))
+		}
+	}
+	// This is form 2
 	name, err := object.AsString(args[0])
 	if err != nil {
 		return err
 	}
-	var strArgs []string
 	for _, arg := range args[1:] {
 		argStr, err := object.AsString(arg)
 		if err != nil {
@@ -49,73 +69,54 @@ func Exec(ctx context.Context, args ...object.Object) object.Object {
 	if err := arg.RequireRange("exec", 1, 3, args); err != nil {
 		return err
 	}
-	program, err := object.AsString(args[0])
-	if err != nil {
-		return err
-	}
+	var wasList bool
+	var program string
 	var optArgs []string
-	if len(args) > 1 {
-		optArgs, err = object.AsStringSlice(args[1])
+	fmt.Println("Exec args", args)
+	if list, err := object.AsList(args[0]); err == nil {
+		wasList = true
+		var args []string
+		for _, arg := range list.Value() {
+			argStr, err := object.AsString(arg)
+			if err != nil {
+				return err
+			}
+			args = append(args, argStr)
+		}
+		if len(args) == 0 {
+			return object.Errorf("exec expected at least one argument in list")
+		}
+		program = args[0]
+		optArgs = args[1:]
+	} else {
+		program, err = object.AsString(args[0])
 		if err != nil {
 			return err
+		}
+		fmt.Println("program", program)
+		if len(args) > 1 {
+			optArgs, err = object.AsStringSlice(args[1])
+			if err != nil {
+				return err
+			}
 		}
 	}
 	cmd := exec.CommandContext(ctx, program, optArgs...)
 
-	if len(args) > 2 {
+	mapOffset := 2
+	if wasList {
+		mapOffset = 1
+	}
+
+	if len(args) > mapOffset {
 		var params *object.Map
 		var errObj *object.Error
-		params, errObj = object.AsMap(args[2])
+		params, errObj = object.AsMap(args[mapOffset])
 		if errObj != nil {
 			return errObj
 		}
-		if stdoutObj := params.GetWithDefault("stdout", nil); stdoutObj != nil {
-			stdoutBuf, ok := stdoutObj.(io.Writer)
-			if !ok {
-				return object.Errorf("eval error: exec expected io.Writer for stdout (%T given)", stdoutObj)
-			}
-			cmd.Stdout = stdoutBuf
-		}
-		if stderrObj := params.GetWithDefault("stderr", nil); stderrObj != nil {
-			stderrBuf, ok := stderrObj.(io.Writer)
-			if !ok {
-				return object.Errorf("eval error: exec expected io.Writer for stderr (%T given)", stderrObj)
-			}
-			cmd.Stderr = stderrBuf
-		}
-		if stdinObj := params.GetWithDefault("stdin", nil); stdinObj != nil {
-			switch stdinObj := stdinObj.(type) {
-			case *object.ByteSlice:
-				cmd.Stdin = bytes.NewBuffer(stdinObj.Value())
-			case *object.String:
-				cmd.Stdin = bytes.NewBufferString(stdinObj.Value())
-			case io.Reader:
-				cmd.Stdin = stdinObj
-			default:
-				return object.Errorf("eval error: exec expected io.Reader for stdin (%T given)", stdinObj)
-			}
-		}
-		if dirObj := params.GetWithDefault("dir", nil); dirObj != nil {
-			dirStr, err := object.AsString(dirObj)
-			if err != nil {
-				return err
-			}
-			cmd.Dir = dirStr
-		}
-		if envObj := params.GetWithDefault("env", nil); envObj != nil {
-			envMap, err := object.AsMap(envObj)
-			if err != nil {
-				return err
-			}
-			var env []string
-			for key, value := range envMap.Value() {
-				valueStr, err := object.AsString(value)
-				if err != nil {
-					return err
-				}
-				env = append(env, fmt.Sprintf("%s=%s", key, valueStr))
-			}
-			cmd.Env = env
+		if err := configureCommand(cmd, params); err != nil {
+			return object.NewError(err)
 		}
 	}
 
@@ -130,6 +131,58 @@ func Exec(ctx context.Context, args ...object.Object) object.Object {
 		return object.NewError(err)
 	}
 	return NewResult(cmd)
+}
+
+func configureCommand(cmd *exec.Cmd, params *object.Map) error {
+	if stdoutObj := params.GetWithDefault("stdout", nil); stdoutObj != nil {
+		stdoutBuf, ok := stdoutObj.(io.Writer)
+		if !ok {
+			return object.Errorf("eval error: exec expected io.Writer for stdout (%T given)", stdoutObj)
+		}
+		cmd.Stdout = stdoutBuf
+	}
+	if stderrObj := params.GetWithDefault("stderr", nil); stderrObj != nil {
+		stderrBuf, ok := stderrObj.(io.Writer)
+		if !ok {
+			return object.Errorf("eval error: exec expected io.Writer for stderr (%T given)", stderrObj)
+		}
+		cmd.Stderr = stderrBuf
+	}
+	if stdinObj := params.GetWithDefault("stdin", nil); stdinObj != nil {
+		switch stdinObj := stdinObj.(type) {
+		case *object.ByteSlice:
+			cmd.Stdin = bytes.NewBuffer(stdinObj.Value())
+		case *object.String:
+			cmd.Stdin = bytes.NewBufferString(stdinObj.Value())
+		case io.Reader:
+			cmd.Stdin = stdinObj
+		default:
+			return object.Errorf("eval error: exec expected io.Reader for stdin (%T given)", stdinObj)
+		}
+	}
+	if dirObj := params.GetWithDefault("dir", nil); dirObj != nil {
+		dirStr, err := object.AsString(dirObj)
+		if err != nil {
+			return err
+		}
+		cmd.Dir = dirStr
+	}
+	if envObj := params.GetWithDefault("env", nil); envObj != nil {
+		envMap, err := object.AsMap(envObj)
+		if err != nil {
+			return err
+		}
+		var env []string
+		for key, value := range envMap.Value() {
+			valueStr, err := object.AsString(value)
+			if err != nil {
+				return err
+			}
+			env = append(env, fmt.Sprintf("%s=%s", key, valueStr))
+		}
+		cmd.Env = env
+	}
+	return nil
 }
 
 func Module() *object.Module {

--- a/modules/exec/exec.md
+++ b/modules/exec/exec.md
@@ -22,7 +22,7 @@ exec(name string, args []string, opts map) result
 
 This provides a shorthand way to build and run a command. The function returns a
 `result` object containing the stdout and stderr produced by running the command.
-The `args` and `opts` arguments are optional.
+The `opts` argument is optional.
 
 ```go copy filename="Example"
 >>> exec(["echo", "TEST"]).stdout

--- a/modules/exec/exec.md
+++ b/modules/exec/exec.md
@@ -7,7 +7,14 @@ shell, expand glob patterns, or handle other shell features.
 
 ## Callable
 
-The `exec` module itself is callable with the following signature:
+The `exec` module itself is callable, using one of two signatures. The preferred
+form is now:
+
+```go filename="Function signature"
+exec(args []string, opts map) result
+```
+
+The old form that is still supported for backwards compatibility is:
 
 ```go filename="Function signature"
 exec(name string, args []string, opts map) result
@@ -18,7 +25,7 @@ This provides a shorthand way to build and run a command. The function returns a
 The `args` and `opts` arguments are optional.
 
 ```go copy filename="Example"
->>> exec("echo", ["TEST"]).stdout
+>>> exec(["echo", "TEST"]).stdout
 byte_slice("TEST\n")
 ```
 
@@ -36,6 +43,14 @@ The `opts` argument may be a map containing any of the following keys:
 
 ### command
 
+Two signatures are supported for the `command` function. The preferred form is now:
+
+```go filename="Function signature"
+command(args []string) command
+```
+
+The old form that is still supported for backwards compatibility is:
+
 ```go filename="Function signature"
 command(name string, args ...string) command
 ```
@@ -46,7 +61,7 @@ Before the command is run, its `path`, `dir`, and `env` attributes may be set.
 Read more about the [command](#command-1) type below.
 
 ```go copy filename="Example"
->>> exec.command("echo", "TEST").output()
+>>> exec.command(["echo", "TEST"]).output()
 byte_slice("TEST\n")
 ```
 

--- a/modules/exec/exec_test.go
+++ b/modules/exec/exec_test.go
@@ -1,0 +1,55 @@
+package exec
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/risor-io/risor/object"
+	"github.com/stretchr/testify/require"
+)
+
+func getStdoutLines(result *Result) []string {
+	stdout := result.Stdout().(*object.String)
+	return strings.Split(stdout.Value(), "\n")
+}
+
+func TestExecOldWay(t *testing.T) {
+	ctx := context.Background()
+	resultObj := Exec(ctx,
+		object.NewString("ls"),
+		object.NewList([]object.Object{object.NewString("-l")}))
+	result, ok := resultObj.(*Result)
+	require.True(t, ok)
+	lines := getStdoutLines(result)
+	require.True(t, len(lines) > 1)
+	var found bool
+	for _, line := range lines {
+		if strings.HasSuffix(line, "exec_test.go") {
+			found = true
+			break
+		}
+	}
+	require.True(t, found)
+}
+
+func TestExecNewWay(t *testing.T) {
+	ctx := context.Background()
+	resultObj := Exec(ctx,
+		object.NewList([]object.Object{
+			object.NewString("ls"),
+			object.NewString("-l"),
+		}))
+	result, ok := resultObj.(*Result)
+	require.True(t, ok)
+	lines := getStdoutLines(result)
+	require.True(t, len(lines) > 1)
+	var found bool
+	for _, line := range lines {
+		if strings.HasSuffix(line, "exec_test.go") {
+			found = true
+			break
+		}
+	}
+	require.True(t, found)
+}

--- a/modules/exec/exec_test.go
+++ b/modules/exec/exec_test.go
@@ -104,12 +104,11 @@ func TestLookPath(t *testing.T) {
 }
 
 func TestConfigureWithBadMaps(t *testing.T) {
-	var cases = []struct {
+	cases := []struct {
 		name     string
 		params   *object.Map
 		expected string
 	}{
-
 		{
 			name: "stdin",
 			params: object.NewMap(map[string]object.Object{

--- a/modules/exec/exec_test.go
+++ b/modules/exec/exec_test.go
@@ -1,7 +1,11 @@
 package exec
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"os/exec"
+	"path"
 	"strings"
 	"testing"
 
@@ -52,4 +56,119 @@ func TestExecNewWay(t *testing.T) {
 		}
 	}
 	require.True(t, found)
+}
+
+func TestConfigureCommand(t *testing.T) {
+	var stderr, stdout bytes.Buffer
+	cmd := &exec.Cmd{}
+	err := configureCommand(cmd,
+		object.NewMap(map[string]object.Object{
+			"dir":    object.NewString("/tmp"),
+			"stdin":  object.NewString("hello"),
+			"stderr": object.NewBuffer(&stderr),
+			"stdout": object.NewBuffer(&stdout),
+			"env": object.NewMap(map[string]object.Object{
+				"FOO": object.NewString("bar"),
+			}),
+		}))
+	require.NoError(t, err)
+
+	require.Equal(t, "/tmp", cmd.Dir)
+	require.NotNil(t, cmd.Stdin)
+	require.NotNil(t, cmd.Stdout)
+	require.NotNil(t, cmd.Stderr)
+	require.Equal(t, []string{"FOO=bar"}, cmd.Env)
+
+	data, err := io.ReadAll(cmd.Stdin)
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(data))
+}
+
+func TestCommandFunc(t *testing.T) {
+	ctx := context.Background()
+	cmdObj, ok := CommandFunc(ctx,
+		object.NewString("ls"),
+		object.NewString("-l")).(*Command)
+	require.True(t, ok)
+	cmd := cmdObj.Value()
+	_, end := path.Split(cmd.Path)
+	require.Equal(t, "ls", end)
+	require.Equal(t, []string{"ls", "-l"}, cmd.Args)
+}
+
+func TestLookPath(t *testing.T) {
+	result := LookPath(context.Background(), object.NewString("ls"))
+	path, ok := result.(*object.String)
+	require.True(t, ok)
+	require.NotEmpty(t, path.Value())
+}
+
+func TestConfigureWithBadMaps(t *testing.T) {
+	var cases = []struct {
+		name     string
+		params   *object.Map
+		expected string
+	}{
+
+		{
+			name: "stdin",
+			params: object.NewMap(map[string]object.Object{
+				"stdin": object.NewList([]object.Object{}),
+			}),
+			expected: "exec expected io.Reader for stdin (got list)",
+		},
+		{
+			name: "stdout",
+			params: object.NewMap(map[string]object.Object{
+				"stdout": object.NewList([]object.Object{}),
+			}),
+
+			expected: "exec expected io.Writer for stdout (got list)",
+		},
+		{
+			name: "stderr",
+			params: object.NewMap(map[string]object.Object{
+				"stderr": object.NewList([]object.Object{}),
+			}),
+			expected: "exec expected io.Writer for stderr (got list)",
+		},
+		{
+			name: "dir",
+			params: object.NewMap(map[string]object.Object{
+				"dir": object.NewList([]object.Object{}),
+			}),
+			expected: "exec expected string for dir (got list)",
+		},
+		{
+			name: "env",
+			params: object.NewMap(map[string]object.Object{
+				"env": object.NewList([]object.Object{}),
+			}),
+			expected: "exec expected map for env (got list)",
+		},
+		{
+			name: "env-value",
+			params: object.NewMap(map[string]object.Object{
+				"env": object.NewMap(map[string]object.Object{
+					"FOO": object.NewList([]object.Object{}),
+				}),
+			}),
+			expected: "exec expected string for env value (got list)",
+		},
+		{
+			name: "unknown-key",
+			params: object.NewMap(map[string]object.Object{
+				"oops": object.NewInt(0),
+			}),
+			expected: "exec found unexpected key \"oops\"",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &exec.Cmd{}
+			err := configureCommand(cmd, tt.params)
+			require.Error(t, err)
+			require.Equal(t, tt.expected, err.Error())
+		})
+	}
 }

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -2198,6 +2198,13 @@ func TestMultivar(t *testing.T) {
 	}), result)
 }
 
+func TestExecWithDir(t *testing.T) {
+	code := `exec(["cat", "jabberwocky.txt"], {dir: "fixtures"}).stdout.split("\n")[0]`
+	result, err := run(context.Background(), code)
+	require.Nil(t, err)
+	require.Equal(t, object.NewString("'Twas brillig, and the slithy toves"), result)
+}
+
 func TestContextDone(t *testing.T) {
 	// Context with no deadline does not return a Done channel
 	ctx := context.Background()

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -2205,6 +2205,13 @@ func TestExecWithDir(t *testing.T) {
 	require.Equal(t, object.NewString("'Twas brillig, and the slithy toves"), result)
 }
 
+func TestExecOldWayWithDir(t *testing.T) {
+	code := `exec("cat", ["jabberwocky.txt"], {dir: "fixtures"}).stdout.split("\n")[0]`
+	result, err := run(context.Background(), code)
+	require.Nil(t, err)
+	require.Equal(t, object.NewString("'Twas brillig, and the slithy toves"), result)
+}
+
 func TestContextDone(t *testing.T) {
 	// Context with no deadline does not return a Done channel
 	ctx := context.Background()


### PR DESCRIPTION
New form:

```
exec(["cat", "jabberwocky.txt"], {dir: "fixtures"})
```

Old form:

```
exec("cat", ["jabberwocky.txt"], {dir: "fixtures"})
```

Both are now supported. The same update was made to the `exec.command` parameters as well.

The intent here is to make it easier to build and pass args lists to execute.