### PR TITLE
Bump gha module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/fatih/color v1.17.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/risor-io/risor/modules/gha v0.0.0-20240213105055-b1d3a53935e5
+	github.com/risor-io/risor/modules/gha v1.6.1-0.20240927135333-245e7b83abf4
 	github.com/stretchr/testify v1.9.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/risor-io/risor/modules/gha v0.0.0-20240213105055-b1d3a53935e5 h1:Q9cJd70SbEARv9oid6AJVersnnicFciXlPk6wA0u2TI=
-github.com/risor-io/risor/modules/gha v0.0.0-20240213105055-b1d3a53935e5/go.mod h1:yat4QxAd5AZHmHMP9KCfrerw+GA2ZMnLriEV3u1DHlM=
+github.com/risor-io/risor/modules/gha v1.6.1-0.20240927135333-245e7b83abf4 h1:NpNMhq5lOkx2TR1UVGSy8tgQ5xWSJbbU0YdHYaKNDPw=
+github.com/risor-io/risor/modules/gha v1.6.1-0.20240927135333-245e7b83abf4/go.mod h1:NeIKOZddXtDiLQlpF3YPFGmy/T4Ca91ZhpUAYO6QELs=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=


### PR DESCRIPTION
Likely caused by the refactor in https://github.com/risor-io/risor/pull/268.

I'm not 100% sure what's going on here but without this, it seems to be pulling a gha module version that still requires internal/arg to be around, and breaks tidy:

```
❯ go mod tidy
go: downloading github.com/stretchr/testify v1.9.0 go: downloading github.com/fatih/color v1.17.0
go: downloading github.com/olekukonko/tablewriter v0.0.5 go: downloading github.com/risor-io/risor/modules/gha v0.0.0-20240213105055-b1d3a53935e5 go: downloading gopkg.in/yaml.v3 v3.0.1
go: downloading github.com/mattn/go-isatty v0.0.20 go: downloading github.com/mattn/go-colorable v0.1.13 go: downloading golang.org/x/sys v0.24.0
go: downloading github.com/mattn/go-runewidth v0.0.16 go: downloading gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c go: downloading github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 go: downloading github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc go: downloading github.com/rivo/uniseg v0.4.7
go: downloading github.com/kr/pretty v0.3.1
go: downloading github.com/rogpeppe/go-internal v1.12.0 go: downloading github.com/kr/text v0.2.0
go: finding module for package github.com/risor-io/risor/internal/arg go: github.com/risor-io/risor/modules/all imports
        github.com/risor-io/risor/modules/gha imports
        github.com/risor-io/risor/internal/arg: no matching versions for query "latest"
```