### PR TITLE
fix call context issue

### DIFF
--- a/vm/vm.go
+++ b/vm/vm.go
@@ -701,7 +701,7 @@ func (vm *VirtualMachine) Call(
 		}
 		vm.stop()
 	}()
-	return vm.callFunction(ctx, fn, args)
+	return vm.callFunction(vm.initContext(ctx), fn, args)
 }
 
 // Calls a compiled function with the given arguments. This is used internally


### PR DESCRIPTION
In some cases, `vm.Call` would return the error `eval error: context did not contain a call function` due to this.