### PR TITLE
http: add support for query parameters

### DIFF
--- a/modules/http/request.go
+++ b/modules/http/request.go
@@ -79,6 +79,12 @@ func (r *HttpRequest) GetAttr(name string) (object.Object, bool) {
 	switch name {
 	case "url":
 		return r.URL(), true
+	case "query":
+		rm := make(map[string]object.Object)
+		for k, v := range r.req.URL.Query() {
+			rm[k] = object.NewString(v[0])
+		}
+		return object.NewMap(rm), true
 	case "content_length":
 		return r.ContentLength(), true
 	case "header":

--- a/modules/http/request_test.go
+++ b/modules/http/request_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestRequestPathValueEmpty(t *testing.T) {
 	ctx := context.Background()
-	u, err := url.Parse("http://example.com?foo=bar")
+	u, err := url.Parse("http://example.com/?foo=bar")
 	require.Nil(t, err)
 
 	req := NewRequest(&http.Request{Method: "GET", URL: u})
@@ -20,6 +20,10 @@ func TestRequestPathValueEmpty(t *testing.T) {
 
 	fn, ok := req.GetAttr("path_value")
 	require.True(t, ok)
+
+	v, ok := req.GetAttr("query")
+	require.True(t, ok)
+	require.Equal(t, object.NewString("bar"), v.(*object.Map).Get("foo"))
 
 	pathValue, ok := fn.(*object.Builtin)
 	require.True(t, ok)

--- a/modules/http/request_test.go
+++ b/modules/http/request_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestRequestPathValueEmpty(t *testing.T) {
 	ctx := context.Background()
-	u, err := url.Parse("http://example.com/?foo=bar")
+	u, err := url.Parse("http://example.com?foo=bar")
 	require.Nil(t, err)
 
 	req := NewRequest(&http.Request{Method: "GET", URL: u})


### PR DESCRIPTION
Adds support for query parameters to HttpRequest:

```Go
http.handle("/search?foo=bar", func(w, r) {
  q := r.query.get("foo")
})
http.listen_and_serve(":9900")
```