### PR TITLE
fix: imports in repl, named functions as expressions

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1147,6 +1147,9 @@ func (c *Compiler) compileFunc(node *ast.Func) error {
 		if err != nil {
 			return err
 		}
+		// Duplicate function on the stack, so that we ensure the function
+		// evaluates to a value even when it's named.
+		c.emit(op.Copy, 0)
 		if c.current.parent == nil {
 			c.emit(op.StoreGlobal, funcSymbol.Index())
 		} else {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -895,7 +895,7 @@ func (vm *VirtualMachine) reloadCode(main *compiler.Code) *code {
 	if !ok {
 		panic("main code not loaded")
 	}
-	vm.loadedCode = map[*compiler.Code]*code{}
+	delete(vm.loadedCode, main)
 	newWrappedMain := vm.loadCode(main)
 	copy(newWrappedMain.Globals, oldWrappedMain.Globals)
 	return newWrappedMain

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -2212,6 +2212,21 @@ func TestExecOldWayWithDir(t *testing.T) {
 	require.Equal(t, object.NewString("'Twas brillig, and the slithy toves"), result)
 }
 
+func TestReturnNamedFunction(t *testing.T) {
+	code := `
+	func test() {
+		return func foo() {
+			return "FOO"
+		}
+	}
+	f := test()
+	f()
+	`
+	result, err := run(context.Background(), code)
+	require.Nil(t, err)
+	require.Equal(t, object.NewString("FOO"), result)
+}
+
 func TestContextDone(t *testing.T) {
 	// Context with no deadline does not return a Done channel
 	ctx := context.Background()


### PR DESCRIPTION
Fixes:
- https://github.com/risor-io/risor/issues/291
- https://github.com/risor-io/risor/issues/288