### PR TITLE
os: Fix index out of range error in the exit method

### DIFF
--- a/modules/os/os.go
+++ b/modules/os/os.go
@@ -33,6 +33,7 @@ func Exit(ctx context.Context, args ...object.Object) object.Object {
 	tos := GetOS(ctx)
 	if nArgs == 0 {
 		tos.Exit(0)
+		return object.Nil
 	}
 	switch obj := args[0].(type) {
 	case *object.Int:


### PR DESCRIPTION
This fixes index of out range error when os.exit is invoked without arguments. The issue is caused by falling through the if statement.

---

Steps to reproduce:

```
$ cat > /tmp/runme.risor
import os
os.exit()
$ risor --virtual-os /tmp/runme.risor
panic: runtime error: index out of range [0] with length 0
```