### PR TITLE
cli: Configure App's Reader, Writer, ErrWriter to use OS' stdin, stdout

### DIFF
--- a/modules/cli/app.go
+++ b/modules/cli/app.go
@@ -91,7 +91,7 @@ func (app *App) GetAttr(name string) (object.Object, bool) {
 	return nil, false
 }
 
-func NewApp(opts *object.Map) (*App, error) {
+func NewApp(ctx context.Context, opts *object.Map) (*App, error) {
 	app := &ucli.App{}
 
 	var err error
@@ -119,6 +119,12 @@ func NewApp(opts *object.Map) (*App, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	stdin := os.GetDefaultOS(ctx).Stdin()
+	stdout := os.GetDefaultOS(ctx).Stdout()
+	app.Reader = stdin
+	app.Writer = stdout
+	app.ErrWriter = stdout
 
 	if actionOpt := opts.Get("action"); actionOpt != object.Nil {
 		if action, ok := actionOpt.(*object.Function); ok {

--- a/modules/cli/cli.go
+++ b/modules/cli/cli.go
@@ -16,7 +16,7 @@ func AppFunc(ctx context.Context, args ...object.Object) object.Object {
 	if objErr != nil {
 		return objErr
 	}
-	app, err := NewApp(opts)
+	app, err := NewApp(ctx, opts)
 	if err != nil {
 		return object.NewError(err)
 	}


### PR DESCRIPTION
The underlying library defaults to use stdlib's os.Stdin and os.Stdout when the fields are not populated. In implementations where OS uses custom files to represent stdin and stdout, incorrect files are used by the App.

This commit assigns App's Reader, Writer, ErrWriter to OS's, Stdin, Stdout. As Risor doesn't have a concept of stderr, stdout is used for ErrWriter instead.