### PR TITLE
Always return struct by pointer

### DIFF
--- a/object/go_field.go
+++ b/object/go_field.go
@@ -90,7 +90,12 @@ func (f *GoField) MarshalJSON() ([]byte, error) {
 }
 
 func newGoField(f reflect.StructField) (*GoField, error) {
-	fieldGoType, err := newGoType(f.Type)
+	typ := f.Type
+	if f.Type.Kind() == reflect.Struct {
+		typ = reflect.PointerTo(typ)
+	}
+
+	fieldGoType, err := newGoType(typ)
 	if err != nil {
 		return nil, err
 	}

--- a/object/go_field_test.go
+++ b/object/go_field_test.go
@@ -1,0 +1,140 @@
+package object
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testStruct struct {
+	Name    string `json:"name"`
+	Age     int    `json:"age"`
+	Enabled bool   `json:"enabled"`
+}
+
+func TestGoField(t *testing.T) {
+	// Create a test instance and get its type
+	s := &testStruct{}
+	typ := reflect.TypeOf(s).Elem()
+
+	// Test string field
+	nameField, ok := typ.FieldByName("Name")
+	require.True(t, ok)
+	field, err := newGoField(nameField)
+	require.Nil(t, err)
+
+	require.Equal(t, "Name", field.Name())
+	require.Equal(t, "string", field.GoType().Name())
+	require.Equal(t, `json:"name"`, string(field.Tag()))
+
+	// Test int field
+	ageField, ok := typ.FieldByName("Age")
+	require.True(t, ok)
+	field, err = newGoField(ageField)
+	require.Nil(t, err)
+
+	require.Equal(t, "Age", field.Name())
+	require.Equal(t, "int", field.GoType().Name())
+	require.Equal(t, `json:"age"`, string(field.Tag()))
+
+	// Test bool field
+	enabledField, ok := typ.FieldByName("Enabled")
+	require.True(t, ok)
+	field, err = newGoField(enabledField)
+	require.Nil(t, err)
+
+	require.Equal(t, "Enabled", field.Name())
+	require.Equal(t, "bool", field.GoType().Name())
+	require.Equal(t, `json:"enabled"`, string(field.Tag()))
+}
+
+type complexStruct struct {
+	Data    map[string]interface{} `json:"data"`
+	Numbers []int                  `json:"numbers"`
+	Ptr     *string                `json:"ptr"`
+}
+
+func TestGoFieldComplexTypes(t *testing.T) {
+	s := complexStruct{}
+	typ := reflect.TypeOf(s)
+
+	// Test map field
+	dataField, ok := typ.FieldByName("Data")
+	require.True(t, ok)
+	field, err := newGoField(dataField)
+	require.Nil(t, err)
+
+	require.Equal(t, "Data", field.Name())
+	require.Equal(t, "map[string]interface {}", field.GoType().Name())
+	require.Equal(t, `json:"data"`, string(field.Tag()))
+
+	// Test slice field
+	numbersField, ok := typ.FieldByName("Numbers")
+	require.True(t, ok)
+	field, err = newGoField(numbersField)
+	require.Nil(t, err)
+
+	require.Equal(t, "Numbers", field.Name())
+	require.Equal(t, "[]int", field.GoType().Name())
+	require.Equal(t, `json:"numbers"`, string(field.Tag()))
+
+	// Test pointer field
+	ptrField, ok := typ.FieldByName("Ptr")
+	require.True(t, ok)
+	field, err = newGoField(ptrField)
+	require.Nil(t, err)
+
+	require.Equal(t, "Ptr", field.Name())
+	require.Equal(t, "*string", field.GoType().Name())
+	require.Equal(t, `json:"ptr"`, string(field.Tag()))
+}
+
+type nestedStruct struct {
+	Inner struct {
+		Value string `json:"value"`
+	} `json:"inner"`
+}
+
+func TestGoFieldNestedStruct(t *testing.T) {
+	s := &nestedStruct{}
+	typ := reflect.TypeOf(s).Elem()
+
+	// Test nested struct field
+	innerField, ok := typ.FieldByName("Inner")
+	require.True(t, ok)
+	field, err := newGoField(innerField)
+	require.Nil(t, err)
+
+	require.Equal(t, "Inner", field.Name())
+	require.Equal(t, "*struct { Value string \"json:\\\"value\\\"\" }", field.GoType().Name())
+	require.Equal(t, `json:"inner"`, string(field.Tag()))
+}
+
+func TestGoFieldGetAttr(t *testing.T) {
+	s := &testStruct{}
+	typ := reflect.TypeOf(s).Elem()
+	nameField, ok := typ.FieldByName("Name")
+	require.True(t, ok)
+	field, err := newGoField(nameField)
+	require.Nil(t, err)
+
+	// Test GetAttr for name
+	nameAttr, ok := field.GetAttr("name")
+	require.True(t, ok)
+	require.Equal(t, "Name", nameAttr.(*String).value)
+
+	// Test GetAttr for type
+	typeAttr, ok := field.GetAttr("type")
+	require.True(t, ok)
+	require.Equal(t, "string", typeAttr.(*GoType).Name())
+
+	// Test GetAttr for tag
+	tagAttr, ok := field.GetAttr("tag")
+	require.True(t, ok)
+	require.Equal(t, `json:"name"`, tagAttr.(*String).value)
+
+	// Test GetAttr for non-existent attribute
+	_, ok = field.GetAttr("nonexistent")
+	require.False(t, ok)
+}

--- a/object/proxy.go
+++ b/object/proxy.go
@@ -78,13 +78,16 @@ func (p *Proxy) GetAttr(name string) (Object, bool) {
 		if !ok {
 			return TypeErrorf("type error: no converter for field %s", name), true
 		}
-		var value interface{}
+		var value reflect.Value
 		if p.typ.IsPointerType() {
-			value = reflect.ValueOf(p.obj).Elem().FieldByName(name).Interface()
+			value = reflect.ValueOf(p.obj).Elem().FieldByName(name)
 		} else {
-			value = reflect.ValueOf(p.obj).FieldByName(name).Interface()
+			value = reflect.ValueOf(p.obj).FieldByName(name)
 		}
-		result, err := conv.From(value)
+		if value.Kind() == reflect.Struct && value.CanAddr() {
+			value = value.Addr()
+		}
+		result, err := conv.From(value.Interface())
 		if err != nil {
 			return NewError(err), true
 		}

--- a/object/proxy_test.go
+++ b/object/proxy_test.go
@@ -433,3 +433,33 @@ func TestProxyHasher(t *testing.T) {
 
 	require.Equal(t, expected, byte_slice.Value())
 }
+
+type nestedStructA struct {
+	B string
+}
+
+type nestedStructConfig struct {
+	A nestedStructA
+}
+
+func TestProxyNestedStruct(t *testing.T) {
+	config := &nestedStructConfig{}
+	proxy, err := object.NewProxy(config)
+	require.Nil(t, err)
+
+	// Get the A field
+	aField, ok := proxy.GetAttr("A")
+	require.True(t, ok)
+
+	// Verify A is a proxy to nestedStructA
+	aProxy, ok := aField.(*object.Proxy)
+	require.True(t, ok)
+	require.Equal(t, "*object_test.nestedStructA", aProxy.GoType().Name())
+
+	// Set B field directly on the A proxy
+	err = aProxy.SetAttr("B", object.NewString("hello"))
+	require.Nil(t, err)
+
+	// Verify the value was set correctly
+	require.Equal(t, "hello", config.A.B)
+}


### PR DESCRIPTION
Currently, if you use:

```golang
type A struct {
  B string
}

type Config struct {
  A A
}

var config Config
risor.NewConfig(risor.WithGlobal("config", &config))
```

You'll get `type error: cannot set field B` for the Risor script:

```golang
config.A.B = "hello"
config
```

This PR ensures that for structs we return by pointer allowing us to set the fields of a nested struct.