### PR TITLE
Add file location information in compiler error messages

### DIFF
--- a/cmd/risor/root.go
+++ b/cmd/risor/root.go
@@ -182,7 +182,11 @@ var rootCmd = &cobra.Command{
 
 		// Execute the code
 		start := time.Now()
-		result, err := risor.Eval(ctx, code, opts...)
+		evalOpts := getRisorOptions()
+		if len(args) > 0 {
+			evalOpts = append(evalOpts, risor.WithFilename(args[0]))
+		}
+		result, err := risor.Eval(ctx, code, evalOpts...)
 		if err != nil {
 			errMsg := err.Error()
 			if friendlyErr, ok := err.(errz.FriendlyError); ok {

--- a/compiler/code.go
+++ b/compiler/code.go
@@ -30,6 +30,7 @@ type Code struct {
 	names        []string
 	source       string
 	functionID   string
+	filename     string // The source file this code came from
 
 	// Used during compilation only
 	loops      []*loop
@@ -156,4 +157,8 @@ func (c *Code) Flatten() []*Code {
 		codes = append(codes, child.Flatten()...)
 	}
 	return codes
+}
+
+func (c *Code) Filename() string {
+	return c.filename
 }

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 
 	"github.com/risor-io/risor/ast"
 	"github.com/risor-io/risor/op"
@@ -40,6 +41,9 @@ type Compiler struct {
 
 	// Increments with each function compiled
 	funcIndex int
+
+	// Source filename
+	filename string
 }
 
 // Option is a configuration function for a Compiler.
@@ -57,6 +61,13 @@ func WithGlobalNames(names []string) Option {
 func WithCode(code *Code) Option {
 	return func(c *Compiler) {
 		c.main = code
+	}
+}
+
+// WithFilename configures the compiler with the source filename.
+func WithFilename(filename string) Option {
+	return func(c *Compiler) {
+		c.filename = filename
 	}
 }
 
@@ -114,6 +125,9 @@ func (c *Compiler) Compile(node ast.Node) (*Code, error) {
 		c.main.source = node.String()
 	} else {
 		c.main.source = fmt.Sprintf("%s\n%s", c.main.source, node.String())
+	}
+	if c.filename != "" {
+		c.main.filename = c.filename
 	}
 	if err := c.compile(node); err != nil {
 		return nil, err
@@ -441,8 +455,7 @@ func (c *Compiler) compileIdent(node *ast.Ident) error {
 	name := node.Literal()
 	resolution, found := c.current.symbols.Resolve(name)
 	if !found {
-		return fmt.Errorf("compile error: undefined variable %q (line %d)",
-			name, node.Token().StartPosition.LineNumber())
+		return c.formatError(fmt.Sprintf("undefined variable %q", name), node.Token().StartPosition)
 	}
 	switch resolution.scope {
 	case Global:
@@ -458,7 +471,7 @@ func (c *Compiler) compileIdent(node *ast.Ident) error {
 func (c *Compiler) compileMultiVar(node *ast.MultiVar) error {
 	names, expr := node.Value()
 	if len(names) > math.MaxUint16 {
-		return fmt.Errorf("compile error: too many variables in multi-variable assignment")
+		return c.formatError("too many variables in multi-variable assignment", node.Token().StartPosition)
 	}
 	// Compile the RHS value
 	if err := c.compile(expr); err != nil {
@@ -486,8 +499,7 @@ func (c *Compiler) compileMultiVar(node *ast.MultiVar) error {
 		name := names[i]
 		resolution, found := c.current.symbols.Resolve(name)
 		if !found {
-			return fmt.Errorf("compile error: undefined variable %q (line %d)",
-				name, node.Token().StartPosition.LineNumber())
+			return c.formatError(fmt.Sprintf("undefined variable %q", name), node.Token().StartPosition)
 		}
 		symbolIndex := resolution.symbol.Index()
 		switch resolution.scope {
@@ -803,8 +815,7 @@ func (c *Compiler) compilePostfix(node *ast.Postfix) error {
 	name := node.Literal()
 	resolution, found := c.current.symbols.Resolve(name)
 	if !found {
-		return fmt.Errorf("compile error: undefined variable %q (line %d)",
-			name, node.Token().StartPosition.LineNumber())
+		return c.formatError(fmt.Sprintf("undefined variable %q", name), node.Token().StartPosition)
 	}
 	symbolIndex := resolution.symbol.Index()
 	// Push the named variable onto the stack
@@ -823,7 +834,7 @@ func (c *Compiler) compilePostfix(node *ast.Postfix) error {
 	} else if operator == "--" {
 		c.emit(op.LoadConst, c.constant(int64(-1)))
 	} else {
-		return fmt.Errorf("compile error: unknown postfix operator %q", operator)
+		return c.formatError(fmt.Sprintf("unknown postfix operator %q", operator), node.Token().StartPosition)
 	}
 	// Run increment or decrement as an Add BinaryOp
 	c.emit(op.BinaryOp, uint16(op.Add))
@@ -1024,7 +1035,7 @@ func (c *Compiler) compileFunc(node *ast.Func) error {
 	// https://stackoverflow.com/questions/23757143/what-is-a-cell-in-the-context-of-an-interpreter-or-compiler
 
 	if len(node.Parameters()) > 255 {
-		return fmt.Errorf("compile error: function exceeded parameter limit of 255")
+		return c.formatError("function exceeded parameter limit of 255", node.Token().StartPosition)
 	}
 
 	// The function has an optional name. If it is named, the name will be
@@ -1083,13 +1094,13 @@ func (c *Compiler) compileFunc(node *ast.Func) error {
 			if defaultsSet[i] {
 				hasDefaults = true
 			} else if hasDefaults {
-				msg := "compile error: invalid argument defaults for"
+				msg := "invalid argument defaults for"
 				if functionName != "" {
 					msg = fmt.Sprintf("%s function %q", msg, functionName)
 				} else {
 					msg = fmt.Sprintf("%s anonymous function", msg)
 				}
-				return fmt.Errorf("%s (line %d)", msg, node.Token().StartPosition.Line+1)
+				return c.formatError(msg, node.Token().StartPosition)
 			}
 		}
 	}
@@ -1164,9 +1175,9 @@ func (c *Compiler) compileControl(node *ast.Control) error {
 	loop := c.currentLoop()
 	if loop == nil {
 		if literal == "break" {
-			return fmt.Errorf("compile error: invalid break statement outside of a loop")
+			return c.formatError("invalid break statement outside of a loop", node.Token().StartPosition)
 		}
-		return fmt.Errorf("compile error: invalid continue statement outside of a loop")
+		return c.formatError("invalid continue statement outside of a loop", node.Token().StartPosition)
 	}
 	if literal == "break" {
 		position := c.emit(op.JumpForward, Placeholder)
@@ -1180,7 +1191,7 @@ func (c *Compiler) compileControl(node *ast.Control) error {
 
 func (c *Compiler) compileReturn(node *ast.Return) error {
 	if c.current.IsRoot() {
-		return fmt.Errorf("compile error: invalid return statement outside of a function")
+		return c.formatError("invalid return statement outside of a function", node.Token().StartPosition)
 	}
 	value := node.Value()
 	if value == nil {
@@ -1220,15 +1231,14 @@ func (c *Compiler) compileAssign(node *ast.Assign) error {
 	if node.Index() != nil {
 		return c.compileSetItem(node)
 	}
-	lineNum := node.Token().StartPosition.LineNumber()
 	name := node.Name()
 	resolution, found := c.current.symbols.Resolve(name)
 	if !found {
-		return fmt.Errorf("compile error: undefined variable %q (line %d)", name, lineNum)
+		return c.formatError(fmt.Sprintf("undefined variable %q", name), node.Token().StartPosition)
 	}
 	sym := resolution.symbol
 	if sym.IsConstant() {
-		return fmt.Errorf("compile error: cannot assign to constant %q (line %d)", name, lineNum)
+		return c.formatError(fmt.Sprintf("cannot assign to constant %q", name), node.Token().StartPosition)
 	}
 	symbolIndex := sym.Index()
 	if node.Operator() == "=" {
@@ -1356,7 +1366,7 @@ func (c *Compiler) compileForRange(forNode *ast.For, names []string, container a
 	for _, pos := range loop.continuePos {
 		delta := jumpBackPos - pos
 		if delta > math.MaxUint16 {
-			return fmt.Errorf("compile error: loop code size exceeded limits")
+			return c.formatError("loop code size exceeded limits", forNode.Token().StartPosition)
 		}
 		c.changeOperand(pos, uint16(delta))
 	}
@@ -1414,8 +1424,6 @@ func (c *Compiler) compileFor(node *ast.For) error {
 		return c.compileSimpleFor(node)
 	}
 
-	lineNum := node.Token().StartPosition.LineNumber()
-
 	// For-Range loop e.g. `for i, value := range container { ... }`
 	if node.Init() == nil && node.Post() == nil {
 		cond := node.Condition()
@@ -1430,7 +1438,7 @@ func (c *Compiler) compileFor(node *ast.For) error {
 		case *ast.MultiVar:
 			names, rhs := cond.Value()
 			if len(names) != 2 {
-				return fmt.Errorf("compile error: invalid for loop (line %d)", lineNum)
+				return c.formatError("invalid for loop", node.Token().StartPosition)
 			}
 			if rangeNode, ok := rhs.(*ast.Range); ok {
 				return c.compileForRange(node, names, rangeNode.Container())
@@ -1442,7 +1450,7 @@ func (c *Compiler) compileFor(node *ast.For) error {
 		case ast.Expression:
 			return c.compileForCondition(node, cond)
 		default:
-			return fmt.Errorf("compile error: invalid for loop (line %d)", lineNum)
+			return c.formatError("invalid for loop", node.Token().StartPosition)
 		}
 	}
 
@@ -1633,7 +1641,6 @@ func (c *Compiler) changeOperand(instructionIndex int, operand uint16) {
 
 func (c *Compiler) compileInfix(node *ast.Infix) error {
 	operator := node.Operator()
-	lineNum := node.Token().StartPosition.LineNumber()
 	// Short-circuit operators
 	if operator == "&&" {
 		return c.compileAnd(node)
@@ -1677,7 +1684,7 @@ func (c *Compiler) compileInfix(node *ast.Infix) error {
 	case "!=":
 		c.emit(op.CompareOp, uint16(op.NotEqual))
 	default:
-		return fmt.Errorf("compile error: unknown operator %q (line %d)", node.Operator(), lineNum)
+		return c.formatError(fmt.Sprintf("unknown operator %q", node.Operator()), node.Token().StartPosition)
 	}
 	return nil
 }
@@ -1740,8 +1747,7 @@ func (c *Compiler) compileGoStmt(node *ast.Go) error {
 
 func (c *Compiler) compileDeferStmt(node *ast.Defer) error {
 	if c.current.parent == nil {
-		return fmt.Errorf("compile error: defer statement outside of a function (line %d)",
-			node.Token().StartPosition.LineNumber())
+		return c.formatError("defer statement outside of a function", node.Token().StartPosition)
 	}
 	expr := node.Call()
 	switch expr := expr.(type) {
@@ -1865,4 +1871,32 @@ func normalizeFunctionBlock(node *ast.Block) []ast.Node {
 		statements = append(statements, returnNil)
 	}
 	return statements
+}
+
+// formatError creates a detailed error message including file, line and column information
+func (c *Compiler) formatError(msg string, pos token.Position) error {
+	var b strings.Builder
+	b.WriteString("compile error: ")
+	b.WriteString(msg)
+	b.WriteString("\n\n")
+	b.WriteString("location: ")
+	if c.filename != "" {
+		b.WriteString("file ")
+		b.WriteString(c.filename)
+		b.WriteString(", ")
+	}
+	b.WriteString(fmt.Sprintf("line %d, column %d", pos.LineNumber(), pos.ColumnNumber()))
+	// add clickable link to file and location
+	b.WriteString(fmt.Sprintf("\n\n%s:%d:%d", c.filename, pos.LineNumber(), pos.ColumnNumber()))
+	if c.current.source != "" {
+		lines := strings.Split(c.current.source, "\n")
+		if pos.Line > 0 && pos.Line <= len(lines) {
+			b.WriteString("\n")
+			b.WriteString(lines[pos.Line-1])
+			b.WriteString("\n")
+			b.WriteString(strings.Repeat(" ", pos.Column-1))
+			b.WriteString("^")
+		}
+	}
+	return fmt.Errorf("%s", b.String())
 }

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -64,10 +64,10 @@ func WithCode(code *Code) Option {
 	}
 }
 
-// WithFilename configures the compiler with the source filename.
-func WithFilename(filename string) Option {
+// WithFile configures the compiler with the source filename.
+func WithFile(file string) Option {
 	return func(c *Compiler) {
-		c.filename = filename
+		c.filename = file
 	}
 }
 
@@ -1875,28 +1875,17 @@ func normalizeFunctionBlock(node *ast.Block) []ast.Node {
 
 // formatError creates a detailed error message including file, line and column information
 func (c *Compiler) formatError(msg string, pos token.Position) error {
+	lineCol := fmt.Sprintf("line %d, column %d", pos.LineNumber(), pos.ColumnNumber())
+	filename := c.filename
+	if filename == "" {
+		filename = "unknown"
+	}
 	var b strings.Builder
 	b.WriteString("compile error: ")
 	b.WriteString(msg)
 	b.WriteString("\n\n")
 	b.WriteString("location: ")
-	if c.filename != "" {
-		b.WriteString("file ")
-		b.WriteString(c.filename)
-		b.WriteString(", ")
-	}
-	b.WriteString(fmt.Sprintf("line %d, column %d", pos.LineNumber(), pos.ColumnNumber()))
-	// add clickable link to file and location
-	b.WriteString(fmt.Sprintf("\n\n%s:%d:%d", c.filename, pos.LineNumber(), pos.ColumnNumber()))
-	if c.current.source != "" {
-		lines := strings.Split(c.current.source, "\n")
-		if pos.Line > 0 && pos.Line <= len(lines) {
-			b.WriteString("\n")
-			b.WriteString(lines[pos.Line-1])
-			b.WriteString("\n")
-			b.WriteString(strings.Repeat(" ", pos.Column-1))
-			b.WriteString("^")
-		}
-	}
+	b.WriteString(fmt.Sprintf("%s:%d:%d", filename, pos.LineNumber(), pos.ColumnNumber()))
+	b.WriteString(fmt.Sprintf(" (%s)", lineCol))
 	return fmt.Errorf("%s", b.String())
 }

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -64,10 +64,10 @@ func WithCode(code *Code) Option {
 	}
 }
 
-// WithFile configures the compiler with the source filename.
-func WithFile(file string) Option {
+// WithFilename configures the compiler with the source filename.
+func WithFilename(filename string) Option {
 	return func(c *Compiler) {
-		c.filename = file
+		c.filename = filename
 	}
 }
 

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -92,7 +92,7 @@ func TestCompileErrors(t *testing.T) {
 	}
 	for _, tt := range testCase {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := New(WithFile("t.risor"))
+			c, err := New(WithFilename("t.risor"))
 			require.Nil(t, err)
 			ast, err := parser.Parse(context.Background(), tt.input)
 			require.Nil(t, err)

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -30,7 +30,7 @@ func TestUndefinedVariable(t *testing.T) {
 		StartPosition: token.Position{Line: 1, Column: 1},
 	}))
 	require.NotNil(t, err)
-	require.Equal(t, "compile error: undefined variable \"foo\" (line 2)", err.Error())
+	require.Equal(t, "compile error: undefined variable \"foo\"\n\nlocation: unknown:2:2 (line 2, column 2)", err.Error())
 }
 
 func TestCompileErrors(t *testing.T) {
@@ -42,32 +42,32 @@ func TestCompileErrors(t *testing.T) {
 		{
 			name:   "undefined variable foo",
 			input:  "foo",
-			errMsg: "compile error: undefined variable \"foo\" (line 1)",
+			errMsg: "compile error: undefined variable \"foo\"\n\nlocation: t.risor:1:1 (line 1, column 1)",
 		},
 		{
 			name:   "undefined variable x",
 			input:  "x = 1",
-			errMsg: "compile error: undefined variable \"x\" (line 1)",
+			errMsg: "compile error: undefined variable \"x\"\n\nlocation: t.risor:1:3 (line 1, column 3)",
 		},
 		{
 			name:   "undefined variable y",
 			input:  "x := 1;\nx, y = [1, 2]",
-			errMsg: "compile error: undefined variable \"y\" (line 2)",
+			errMsg: "compile error: undefined variable \"y\"\n\nlocation: t.risor:2:1 (line 2, column 1)",
 		},
 		{
 			name:   "undefined variable z",
 			input:  "\n\n z++;",
-			errMsg: "compile error: undefined variable \"z\" (line 3)",
+			errMsg: "compile error: undefined variable \"z\"\n\nlocation: t.risor:3:2 (line 3, column 2)",
 		},
 		{
 			name:   "invalid argument defaults",
 			input:  "func bad(a=1, b) {}",
-			errMsg: "compile error: invalid argument defaults for function \"bad\" (line 1)",
+			errMsg: "compile error: invalid argument defaults for function \"bad\"\n\nlocation: t.risor:1:1 (line 1, column 1)",
 		},
 		{
 			name:   "invalid argument defaults for anonymous function",
 			input:  "func(a=1, b) {}()",
-			errMsg: "compile error: invalid argument defaults for anonymous function (line 1)",
+			errMsg: "compile error: invalid argument defaults for anonymous function\n\nlocation: t.risor:1:1 (line 1, column 1)",
 		},
 		{
 			name:   "unsupported default value",
@@ -77,22 +77,22 @@ func TestCompileErrors(t *testing.T) {
 		{
 			name:   "cannot assign to constant",
 			input:  "const a = 1; a = 2",
-			errMsg: "compile error: cannot assign to constant \"a\" (line 1)",
+			errMsg: "compile error: cannot assign to constant \"a\"\n\nlocation: t.risor:1:16 (line 1, column 16)",
 		},
 		{
 			name:   "invalid for loop",
 			input:  "\nfor a, b, c := range [1, 2, 3] {}",
-			errMsg: "compile error: invalid for loop (line 2)",
+			errMsg: "compile error: invalid for loop\n\nlocation: t.risor:2:1 (line 2, column 1)",
 		},
 		{
 			name:   "unknown operator",
 			input:  "\n defer func() {}()",
-			errMsg: "compile error: defer statement outside of a function (line 2)",
+			errMsg: "compile error: defer statement outside of a function\n\nlocation: t.risor:2:2 (line 2, column 2)",
 		},
 	}
 	for _, tt := range testCase {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := New()
+			c, err := New(WithFile("t.risor"))
 			require.Nil(t, err)
 			ast, err := parser.Parse(context.Background(), tt.input)
 			require.Nil(t, err)
@@ -117,5 +117,5 @@ for _, v := range [1, 2, 3] {
 	require.Nil(t, err)
 	_, err = c.Compile(ast)
 	require.NotNil(t, err)
-	require.Equal(t, "compile error: undefined variable \"undefined_var\" (line 4)", err.Error())
+	require.Equal(t, "compile error: undefined variable \"undefined_var\"\n\nlocation: unknown:4:3 (line 4, column 3)", err.Error())
 }

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -76,7 +76,7 @@ func (i *LocalImporter) Import(ctx context.Context, name string) (*object.Module
 	if len(i.globalNames) > 0 {
 		opts = append(opts, compiler.WithGlobalNames(i.globalNames))
 	}
-	opts = append(opts, compiler.WithFile(fullPath))
+	opts = append(opts, compiler.WithFilename(fullPath))
 	code, err := compiler.Compile(ast, opts...)
 	if err != nil {
 		return nil, err

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -68,7 +68,7 @@ func (i *LocalImporter) Import(ctx context.Context, name string) (*object.Module
 	if !found {
 		return nil, fmt.Errorf("import error: module %q not found", name)
 	}
-	ast, err := parser.Parse(ctx, source)
+	ast, err := parser.Parse(ctx, source, parser.WithFile(fullPath))
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func (i *LocalImporter) Import(ctx context.Context, name string) (*object.Module
 	if len(i.globalNames) > 0 {
 		opts = append(opts, compiler.WithGlobalNames(i.globalNames))
 	}
-	opts = append(opts, compiler.WithFilename(fullPath))
+	opts = append(opts, compiler.WithFile(fullPath))
 	code, err := compiler.Compile(ast, opts...)
 	if err != nil {
 		return nil, err

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -47,9 +47,18 @@ func Parse(ctx context.Context, input string, options ...Option) (*ast.Program, 
 type Option func(*Parser)
 
 // WithFile sets the file name for the Lexer.
+//
+// Deprecated: Use WithFilename instead.
 func WithFile(file string) Option {
 	return func(l *Parser) {
 		l.filename = file
+	}
+}
+
+// WithFilename sets the file name for the Lexer.
+func WithFilename(filename string) Option {
+	return func(l *Parser) {
+		l.filename = filename
 	}
 }
 

--- a/risor.go
+++ b/risor.go
@@ -16,7 +16,11 @@ import (
 func Eval(ctx context.Context, source string, options ...Option) (object.Object, error) {
 	cfg := NewConfig(options...)
 	// Parse the source code to create the AST
-	ast, err := parser.Parse(ctx, source)
+	var parserOpts []parser.Option
+	if cfg.filename != "" {
+		parserOpts = append(parserOpts, parser.WithFile(cfg.filename))
+	}
+	ast, err := parser.Parse(ctx, source, parserOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/risor_config.go
+++ b/risor_config.go
@@ -202,7 +202,7 @@ func (cfg *Config) CompilerOpts() []compiler.Option {
 		opts = append(opts, compiler.WithGlobalNames(globalNames))
 	}
 	if cfg.filename != "" {
-		opts = append(opts, compiler.WithFile(cfg.filename))
+		opts = append(opts, compiler.WithFilename(cfg.filename))
 	}
 	return opts
 }

--- a/risor_config.go
+++ b/risor_config.go
@@ -202,7 +202,7 @@ func (cfg *Config) CompilerOpts() []compiler.Option {
 		opts = append(opts, compiler.WithGlobalNames(globalNames))
 	}
 	if cfg.filename != "" {
-		opts = append(opts, compiler.WithFilename(cfg.filename))
+		opts = append(opts, compiler.WithFile(cfg.filename))
 	}
 	return opts
 }

--- a/risor_config.go
+++ b/risor_config.go
@@ -40,6 +40,7 @@ type Config struct {
 	withConcurrency       bool
 	listenersAllowed      bool
 	initialized           bool
+	filename              string
 }
 
 // NewConfig returns a new Risor Config. Use the Risor options functions
@@ -199,6 +200,9 @@ func (cfg *Config) CompilerOpts() []compiler.Option {
 	var opts []compiler.Option
 	if len(globalNames) > 0 {
 		opts = append(opts, compiler.WithGlobalNames(globalNames))
+	}
+	if cfg.filename != "" {
+		opts = append(opts, compiler.WithFilename(cfg.filename))
 	}
 	return opts
 }

--- a/risor_options.go
+++ b/risor_options.go
@@ -82,3 +82,10 @@ func WithListenersAllowed() Option {
 		cfg.listenersAllowed = true
 	}
 }
+
+// WithFilename sets the filename for the source code being evaluated.
+func WithFilename(filename string) Option {
+	return func(cfg *Config) {
+		cfg.filename = filename
+	}
+}

--- a/risor_test.go
+++ b/risor_test.go
@@ -26,15 +26,15 @@ func TestConfirmNoBuiltins(t *testing.T) {
 	testCases := []testCase{
 		{
 			input:       "keys({foo: 1})",
-			expectedErr: "compile error: undefined variable \"keys\" (line 1)",
+			expectedErr: "compile error: undefined variable \"keys\"\n\nlocation: unknown:1:1 (line 1, column 1)",
 		},
 		{
 			input:       "any([0, 0, 1])",
-			expectedErr: "compile error: undefined variable \"any\" (line 1)",
+			expectedErr: "compile error: undefined variable \"any\"\n\nlocation: unknown:1:1 (line 1, column 1)",
 		},
 		{
 			input:       "string(42)",
-			expectedErr: "compile error: undefined variable \"string\" (line 1)",
+			expectedErr: "compile error: undefined variable \"string\"\n\nlocation: unknown:1:1 (line 1, column 1)",
 		},
 	}
 	for _, tc := range testCases {
@@ -90,11 +90,11 @@ func TestWithDenyList(t *testing.T) {
 		},
 		{
 			input:       "any([0, 0, 1])",
-			expectedErr: errors.New(`compile error: undefined variable "any" (line 1)`),
+			expectedErr: errors.New("compile error: undefined variable \"any\"\n\nlocation: unknown:1:1 (line 1, column 1)"),
 		},
 		{
 			input:       "json.marshal(42)",
-			expectedErr: errors.New(`compile error: undefined variable "json" (line 1)`),
+			expectedErr: errors.New("compile error: undefined variable \"json\"\n\nlocation: unknown:1:1 (line 1, column 1)"),
 		},
 		{
 			input:       `os.getenv("USER")`,
@@ -111,12 +111,12 @@ exit(1)`,
 		},
 		{
 			input:       "cat /etc/issue",
-			expectedErr: errors.New(`compile error: undefined variable "cat" (line 1)`),
+			expectedErr: errors.New("compile error: undefined variable \"cat\"\n\nlocation: unknown:1:1 (line 1, column 1)"),
 		},
 	}
 	for _, tc := range testCases {
 		_, err := Eval(context.Background(), tc.input, WithoutGlobals("any", "os.exit", "json", "cat"))
-		t.Logf("want: %q; got: %v", tc.expectedErr, err)
+		// t.Logf("want: %q; got: %v", tc.expectedErr, err)
 		if tc.expectedErr != nil {
 			require.NotNil(t, err)
 			require.Equal(t, tc.expectedErr.Error(), err.Error())
@@ -129,13 +129,13 @@ exit(1)`,
 func TestWithoutDefaultGlobals(t *testing.T) {
 	_, err := Eval(context.Background(), "json.marshal(42)", WithoutDefaultGlobals())
 	require.NotNil(t, err)
-	require.Equal(t, errors.New("compile error: undefined variable \"json\" (line 1)"), err)
+	require.Equal(t, errors.New("compile error: undefined variable \"json\"\n\nlocation: unknown:1:1 (line 1, column 1)"), err)
 }
 
 func TestWithoutDefaultGlobal(t *testing.T) {
 	_, err := Eval(context.Background(), "json.marshal(42)", WithoutGlobal("json"))
 	require.NotNil(t, err)
-	require.Equal(t, errors.New("compile error: undefined variable \"json\" (line 1)"), err)
+	require.Equal(t, errors.New("compile error: undefined variable \"json\"\n\nlocation: unknown:1:1 (line 1, column 1)"), err)
 }
 
 func TestWithVirtualOSStdinBuffer(t *testing.T) {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -608,7 +608,7 @@ func TestRecursiveExample2(t *testing.T) {
 func TestConstant(t *testing.T) {
 	_, err := run(context.Background(), `const x = 1; x = 2`)
 	require.NotNil(t, err)
-	require.Equal(t, "compile error: cannot assign to constant \"x\" (line 1)", err.Error())
+	require.Equal(t, "compile error: cannot assign to constant \"x\"\n\nlocation: unknown:1:16 (line 1, column 16)", err.Error())
 }
 
 func TestConstantFunction(t *testing.T) {
@@ -617,7 +617,7 @@ func TestConstantFunction(t *testing.T) {
 	add = "bloop"
 	`)
 	require.NotNil(t, err)
-	require.Equal(t, "compile error: cannot assign to constant \"add\" (line 3)", err.Error())
+	require.Equal(t, "compile error: cannot assign to constant \"add\"\n\nlocation: unknown:3:6 (line 3, column 6)", err.Error())
 }
 
 func TestStatementsNilValue(t *testing.T) {


### PR DESCRIPTION
Draft PR for https://github.com/risor-io/risor/issues/301

Compile errors now include the filename and source location:

```
compile error: undefined variable "g"

location: tmp2.risor:17:1 (line 17, column 1)
```