### PR TITLE
More compound operation fixes

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1590,15 +1590,20 @@ func (p *Parser) parseGetAttr(objNode ast.Node) ast.Node {
 			return nil
 		}
 		return ast.NewObjectCall(period, obj, call)
-	} else if p.peekTokenIs(token.ASSIGN) {
-		p.nextToken() // move to the "="
+	} else if p.peekTokenIs(token.ASSIGN) ||
+		p.peekTokenIs(token.PLUS_EQUALS) ||
+		p.peekTokenIs(token.MINUS_EQUALS) ||
+		p.peekTokenIs(token.ASTERISK_EQUALS) ||
+		p.peekTokenIs(token.SLASH_EQUALS) {
+		p.nextToken() // move to the operator
+		operator := p.curToken
 		p.nextToken() // move to the value
 		right := p.parseExpression(LOWEST)
 		if right == nil {
 			p.setTokenError(p.curToken, "invalid assignment statement value")
 			return nil
 		}
-		return ast.NewSetAttr(obj.Token(), obj, name, right)
+		return ast.NewSetAttr(operator, obj, name, right)
 	}
 	return ast.NewGetAttr(period, obj, name)
 }

--- a/risor_test.go
+++ b/risor_test.go
@@ -364,3 +364,28 @@ func TestWithConcurrency(t *testing.T) {
 	require.NotNil(t, err)
 	require.Equal(t, "eval error: context did not contain a spawn function", err.Error())
 }
+
+func TestStructFieldModification(t *testing.T) {
+	type Object struct {
+		A int
+	}
+
+	testCases := []struct {
+		script   string
+		expected int64
+	}{
+		{"Object.A = 9; Object.A *= 3; Object.A", 27},
+		{"Object.A = 10; Object.A += 5; Object.A", 15},
+		{"Object.A = 10; Object.A -= 3; Object.A", 7},
+		{"Object.A = 20; Object.A /= 4; Object.A", 5},
+	}
+
+	for _, tc := range testCases {
+		result, err := Eval(context.Background(),
+			tc.script,
+			WithGlobal("Object", &Object{}))
+
+		require.Nil(t, err, "script: %s", tc.script)
+		require.Equal(t, object.NewInt(tc.expected), result, "script: %s", tc.script)
+	}
+}


### PR DESCRIPTION
Fixes compound operations in cases like this:

```go
package main

import (
	"context"
	"fmt"

	"github.com/risor-io/risor"
)

type Object struct {
	A int
}

func main() {
	src := "Object.A = 9; Object.A *= 3; Object.A"
	result, err := risor.Eval(context.Background(), src,
		risor.WithGlobal("Object", &Object{}))
	if err != nil {
		panic(err)
	}
	fmt.Println(result)
}
```