### PR TITLE
os: Do not return an error when exit code is 0

### DIFF
--- a/modules/os/os.go
+++ b/modules/os/os.go
@@ -37,8 +37,12 @@ func Exit(ctx context.Context, args ...object.Object) object.Object {
 	}
 	switch obj := args[0].(type) {
 	case *object.Int:
-		tos.Exit(int(obj.Value()))
-		return object.EvalErrorf("eval error: exit(%d)", obj.Value())
+		code := int(obj.Value())
+		tos.Exit(code)
+		if code != 0 {
+			return object.EvalErrorf("eval error: exit(%d)", obj.Value())
+		}
+		return object.Nil
 	case *object.Error:
 		tos.Exit(1)
 		return object.EvalErrorf("eval error: exit(%s)", obj.Value().Error())


### PR DESCRIPTION
I have inadvertently introduced inconsistency in the behavior of os.exit function in #297. This is only obvious when using custom OS implementation:

- `os.exit()` exits with 0 and the method returns `Object.Nil`.
- `os.exit(0)` exits with 0 and the method returns `Object.Error`.

My other issue is that exit code 0 is currently treated as an error. I checked and Windows, Linux, and Darwin treat only a non-zero exit code as an error. I think it makes sense to follow this convention.