### PR TITLE
Add WithOS option

### DIFF
--- a/cmd/risor/root.go
+++ b/cmd/risor/root.go
@@ -11,12 +11,13 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	"github.com/risor-io/risor"
 	"github.com/risor-io/risor/cmd/risor/repl"
 	"github.com/risor-io/risor/errz"
 	ros "github.com/risor-io/risor/os"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -149,6 +150,8 @@ var rootCmd = &cobra.Command{
 		args, scriptArgs = getScriptArgs(args)
 		ros.SetScriptArgs(scriptArgs)
 
+		opts := getRisorOptions()
+
 		// Optional virtual operating system with filesystem mounts.
 		if viper.GetBool("virtual-os") {
 			mounts := map[string]*ros.Mount{}
@@ -161,10 +164,8 @@ var rootCmd = &cobra.Command{
 				mounts[dst] = &ros.Mount{Source: fs, Target: dst}
 			}
 			vos := ros.NewVirtualOS(ctx, ros.WithMounts(mounts), ros.WithArgs(scriptArgs))
-			ctx = ros.WithOS(ctx, vos)
+			opts = append(opts, risor.WithOS(vos))
 		}
-
-		opts := getRisorOptions()
 
 		// Run the REPL if no code was provided
 		if shouldRunRepl(cmd, args) {

--- a/examples/go/isolated_io/main.go
+++ b/examples/go/isolated_io/main.go
@@ -28,9 +28,7 @@ func main() {
 		ros.WithStdin(stdin),
 		ros.WithStdout(stdout))
 
-	scriptCtx := ros.WithOS(ctx, virtualOS)
-
-	result, err := risor.Eval(scriptCtx, script)
+	result, err := risor.Eval(ctx, script, risor.WithOS(virtualOS))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/risor_config.go
+++ b/risor_config.go
@@ -26,6 +26,7 @@ import (
 	modTime "github.com/risor-io/risor/modules/time"
 	modYAML "github.com/risor-io/risor/modules/yaml"
 	"github.com/risor-io/risor/object"
+	"github.com/risor-io/risor/os"
 	"github.com/risor-io/risor/vm"
 )
 
@@ -35,6 +36,7 @@ type Config struct {
 	overrides             map[string]any
 	denylist              map[string]bool
 	importer              importer.Importer
+	os                    os.OS
 	localImportPath       string
 	withoutDefaultGlobals bool
 	withConcurrency       bool
@@ -225,6 +227,9 @@ func (cfg *Config) VMOpts() []vm.Option {
 	}
 	if importer != nil {
 		opts = append(opts, vm.WithImporter(importer))
+	}
+	if cfg.os != nil {
+		opts = append(opts, vm.WithOS(cfg.os))
 	}
 	if cfg.withConcurrency {
 		opts = append(opts, vm.WithConcurrency())

--- a/risor_options.go
+++ b/risor_options.go
@@ -1,6 +1,9 @@
 package risor
 
-import "github.com/risor-io/risor/importer"
+import (
+	"github.com/risor-io/risor/importer"
+	"github.com/risor-io/risor/os"
+)
 
 // Option describes a function used to configure a Risor evaluation.
 type Option func(*Config)
@@ -87,5 +90,14 @@ func WithListenersAllowed() Option {
 func WithFilename(filename string) Option {
 	return func(cfg *Config) {
 		cfg.filename = filename
+	}
+}
+
+// WithOS sets custom OS implementation in the context. This context is present
+// in the invocation of Risor builtins, this OS will be used for all related
+// functionality.
+func WithOS(os os.OS) Option {
+	return func(cfg *Config) {
+		cfg.os = os
 	}
 }

--- a/risor_test.go
+++ b/risor_test.go
@@ -148,6 +148,17 @@ func TestWithVirtualOSStdinBuffer(t *testing.T) {
 	require.Equal(t, object.NewByteSlice([]byte("hello")), result)
 }
 
+func TestWithVirtualOSStdinBufferViaContext(t *testing.T) {
+	ctx := context.Background()
+	stdinBuf := ros.NewBufferFile([]byte("hello"))
+	vos := ros.NewVirtualOS(ctx, ros.WithStdin(stdinBuf))
+	ctx = ros.WithOS(ctx, vos)
+
+	result, err := Eval(ctx, "os.stdin.read()")
+	require.Nil(t, err)
+	require.Equal(t, object.NewByteSlice([]byte("hello")), result)
+}
+
 func TestWithVirtualOSStdoutBuffer(t *testing.T) {
 	ctx := context.Background()
 	stdoutBuf := ros.NewBufferFile(nil)

--- a/risor_test.go
+++ b/risor_test.go
@@ -142,9 +142,8 @@ func TestWithVirtualOSStdinBuffer(t *testing.T) {
 	ctx := context.Background()
 	stdinBuf := ros.NewBufferFile([]byte("hello"))
 	vos := ros.NewVirtualOS(ctx, ros.WithStdin(stdinBuf))
-	ctx = ros.WithOS(ctx, vos)
 
-	result, err := Eval(ctx, "os.stdin.read()")
+	result, err := Eval(ctx, "os.stdin.read()", WithOS(vos))
 	require.Nil(t, err)
 	require.Equal(t, object.NewByteSlice([]byte("hello")), result)
 }
@@ -153,9 +152,8 @@ func TestWithVirtualOSStdoutBuffer(t *testing.T) {
 	ctx := context.Background()
 	stdoutBuf := ros.NewBufferFile(nil)
 	vos := ros.NewVirtualOS(ctx, ros.WithStdout(stdoutBuf))
-	ctx = ros.WithOS(ctx, vos)
 
-	result, err := Eval(ctx, "os.stdout.write('foo')")
+	result, err := Eval(ctx, "os.stdout.write('foo')", WithOS(vos))
 	require.Nil(t, err)
 	require.Equal(t, object.NewInt(int64(len("foo"))), result)
 
@@ -166,9 +164,8 @@ func TestStdinListBuffer(t *testing.T) {
 	ctx := context.Background()
 	stdinBuf := ros.NewBufferFile([]byte("foo\nbar!"))
 	vos := ros.NewVirtualOS(ctx, ros.WithStdin(stdinBuf))
-	ctx = ros.WithOS(ctx, vos)
 
-	result, err := Eval(ctx, "list(os.stdin)")
+	result, err := Eval(ctx, "list(os.stdin)", WithOS(vos))
 	require.Nil(t, err)
 	require.Equal(t, object.NewList([]object.Object{
 		object.NewString("foo"),
@@ -180,9 +177,8 @@ func TestWithVirtualOSStdin(t *testing.T) {
 	ctx := context.Background()
 	stdinBuf := ros.NewInMemoryFile([]byte("hello"))
 	vos := ros.NewVirtualOS(ctx, ros.WithStdin(stdinBuf))
-	ctx = ros.WithOS(ctx, vos)
 
-	result, err := Eval(ctx, "os.stdin.read()")
+	result, err := Eval(ctx, "os.stdin.read()", WithOS(vos))
 	require.Nil(t, err)
 	require.Equal(t, object.NewByteSlice([]byte("hello")), result)
 }
@@ -191,9 +187,8 @@ func TestWithVirtualOSStdout(t *testing.T) {
 	ctx := context.Background()
 	stdoutBuf := ros.NewInMemoryFile(nil)
 	vos := ros.NewVirtualOS(ctx, ros.WithStdout(stdoutBuf))
-	ctx = ros.WithOS(ctx, vos)
 
-	result, err := Eval(ctx, "os.stdout.write('foo')")
+	result, err := Eval(ctx, "os.stdout.write('foo')", WithOS(vos))
 	require.Nil(t, err)
 	require.Equal(t, object.NewInt(int64(len("foo"))), result)
 
@@ -205,9 +200,8 @@ func TestStdinList(t *testing.T) {
 	ctx := context.Background()
 	stdinBuf := ros.NewInMemoryFile([]byte("foo\nbar!"))
 	vos := ros.NewVirtualOS(ctx, ros.WithStdin(stdinBuf))
-	ctx = ros.WithOS(ctx, vos)
 
-	result, err := Eval(ctx, "list(os.stdin)")
+	result, err := Eval(ctx, "list(os.stdin)", WithOS(vos))
 	require.Nil(t, err)
 	require.Equal(t, object.NewList([]object.Object{
 		object.NewString("foo"),

--- a/vm/options.go
+++ b/vm/options.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"github.com/risor-io/risor/importer"
+	"github.com/risor-io/risor/os"
 )
 
 // Option is a configuration function for a Virtual Machine.
@@ -34,5 +35,14 @@ func WithGlobals(globals map[string]any) Option {
 func WithConcurrency() Option {
 	return func(vm *VirtualMachine) {
 		vm.concAllowed = true
+	}
+}
+
+// WithOS sets custom OS implementation in the context. This context is present
+// in the invocation of Risor builtins, this OS will be used for all related
+// functionality.
+func WithOS(os os.OS) Option {
+	return func(vm *VirtualMachine) {
+		vm.os = os
 	}
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -974,12 +974,14 @@ func (vm *VirtualMachine) Clone() (*VirtualMachine, error) {
 	}
 
 	clone := &VirtualMachine{
-		sp:           -1,
-		ip:           0,
-		fp:           0,
-		running:      false,
-		importer:     vm.importer,
-		os:           vm.os, // FIXME: OS will not be copied if it was specified via a context value!
+		sp:       -1,
+		ip:       0,
+		fp:       0,
+		running:  false,
+		importer: vm.importer,
+		// If the OS is specified via a context value, it is not cloned here.
+		// The OS is expected to be provided similarly to the cloned VM.
+		os:           vm.getOS(context.Background()),
 		main:         vm.main,
 		inputGlobals: vm.inputGlobals,
 		globals:      vm.globals,

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -112,7 +112,6 @@ func (vm *VirtualMachine) Run(ctx context.Context) (err error) {
 	// 1. It is an error to call Run on a VM that is already running
 	// 2. The running flag will always be set to false when Run returns
 	// 3. Any panics are translated to errors and the VM is stopped
-	ctx = os.WithOS(ctx, vm.os)
 	if err := vm.start(ctx); err != nil {
 		return err
 	}
@@ -697,7 +696,6 @@ func (vm *VirtualMachine) Call(
 	fn *object.Function,
 	args []object.Object,
 ) (result object.Object, err error) {
-	ctx = os.WithOS(ctx, vm.os)
 	if err := vm.start(ctx); err != nil {
 		return nil, err
 	}
@@ -1018,6 +1016,9 @@ func (vm *VirtualMachine) cloneCallSync(
 }
 
 func (vm *VirtualMachine) initContext(ctx context.Context) context.Context {
+	if vm.os != nil {
+		ctx = os.WithOS(ctx, vm.os)
+	}
 	ctx = object.WithCallFunc(ctx, vm.callFunction)
 	if vm.concAllowed {
 		ctx = object.WithSpawnFunc(ctx, vm.cloneCallAsync)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -37,7 +37,7 @@ type VirtualMachine struct {
 	activeCode  *code
 	main        *compiler.Code
 	importer    importer.Importer
-	// os holds reference to OS specified with WithOS option.
+	// os holds reference to OS as wspecified with WithOS option.
 	// The field may be nil as older Risor versions did not have this option available.
 	// To safely obtain current OS reference always use vm.getOS method.
 	os           os.OS
@@ -979,7 +979,7 @@ func (vm *VirtualMachine) Clone() (*VirtualMachine, error) {
 		fp:           0,
 		running:      false,
 		importer:     vm.importer,
-		os:           vm.os,
+		os:           vm.os, // FIXME: OS will not be copied if it was specified via a context value!
 		main:         vm.main,
 		inputGlobals: vm.inputGlobals,
 		globals:      vm.globals,

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -979,6 +979,7 @@ func (vm *VirtualMachine) Clone() (*VirtualMachine, error) {
 		fp:           0,
 		running:      false,
 		importer:     vm.importer,
+		os:           vm.os,
 		main:         vm.main,
 		inputGlobals: vm.inputGlobals,
 		globals:      vm.globals,

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -15,6 +15,7 @@ import (
 	"github.com/risor-io/risor/importer"
 	"github.com/risor-io/risor/object"
 	"github.com/risor-io/risor/op"
+	"github.com/risor-io/risor/os"
 )
 
 const (
@@ -36,6 +37,7 @@ type VirtualMachine struct {
 	activeCode   *code
 	main         *compiler.Code
 	importer     importer.Importer
+	os           os.OS
 	modules      map[string]*object.Module
 	inputGlobals map[string]any
 	globals      map[string]object.Object
@@ -110,6 +112,7 @@ func (vm *VirtualMachine) Run(ctx context.Context) (err error) {
 	// 1. It is an error to call Run on a VM that is already running
 	// 2. The running flag will always be set to false when Run returns
 	// 3. Any panics are translated to errors and the VM is stopped
+	ctx = os.WithOS(ctx, vm.os)
 	if err := vm.start(ctx); err != nil {
 		return err
 	}
@@ -694,6 +697,7 @@ func (vm *VirtualMachine) Call(
 	fn *object.Function,
 	args []object.Object,
 ) (result object.Object, err error) {
+	ctx = os.WithOS(ctx, vm.os)
 	if err := vm.start(ctx); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
WithOS options provides convenient way to provide custom OS implementation to Risor VM without having to modify context manually.