### PR TITLE
importer: Add FSImporter

### DIFF
--- a/importer/fixtures/foo/bar.risor
+++ b/importer/fixtures/foo/bar.risor
@@ -1,0 +1,4 @@
+
+func bar() {
+    return 987
+}

--- a/importer/fixtures/foo/example.rriissoorr
+++ b/importer/fixtures/foo/example.rriissoorr
@@ -1,0 +1,2 @@
+
+func hello() { return "world" }

--- a/importer/fs_importer.go
+++ b/importer/fs_importer.go
@@ -1,0 +1,93 @@
+package importer
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"sync"
+
+	"github.com/risor-io/risor/compiler"
+	"github.com/risor-io/risor/object"
+)
+
+// FSImporterOptions configure an Importer that can read from a filesystem
+// implementing the `fs.FS` interface.
+type FSImporterOptions struct {
+	// Global names that should be available when the module is compiled.
+	GlobalNames []string
+
+	// The filesystem to search for Risor modules.
+	SourceFS fs.FS
+
+	// Optional list of file extensions to try when locating a Risor module.
+	Extensions []string
+}
+
+// FSImporter is an Importer that can read Risor code modules from a filesystem
+// implementing the `fs.FS` interface.
+type FSImporter struct {
+	globalNames []string
+	codeCache   map[string]*compiler.Code
+	sourceFS    fs.FS
+	extensions  []string
+	mutex       sync.Mutex
+}
+
+// NewFSImporter returns an Importer that can read Risor code modules from a
+// filesystem implementing the `fs.FS` interface.
+func NewFSImporter(opts FSImporterOptions) *FSImporter {
+	if opts.Extensions == nil {
+		opts.Extensions = defaultExtensions
+	}
+	return &FSImporter{
+		globalNames: opts.GlobalNames,
+		codeCache:   map[string]*compiler.Code{},
+		sourceFS:    opts.SourceFS,
+		extensions:  opts.Extensions,
+	}
+}
+
+// Import a module by name.
+func (i *FSImporter) Import(ctx context.Context, name string) (*object.Module, error) {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+
+	if code, ok := i.codeCache[name]; ok {
+		return object.NewModule(name, code), nil
+	}
+
+	source, fullPath, found := i.readFileWithExtensions(name, i.extensions)
+	if !found {
+		return nil, fmt.Errorf("import error: module %q not found", name)
+	}
+
+	code, err := parseAndCompile(ctx, source, fullPath, i.globalNames)
+	if err != nil {
+		return nil, err
+	}
+
+	i.codeCache[name] = code
+
+	return object.NewModule(name, code), nil
+}
+
+func (i *FSImporter) readFileWithExtensions(name string, extensions []string) (string, string, bool) {
+	for _, ext := range extensions {
+		fullName := name + ext
+		f, err := i.sourceFS.Open(fullName)
+		if err != nil {
+			continue
+		}
+
+		b, err := io.ReadAll(f)
+		if err != nil {
+			f.Close()
+			continue
+		}
+
+		f.Close()
+		return string(b), fullName, true
+	}
+	return "", "", false
+}

--- a/importer/fs_importer_test.go
+++ b/importer/fs_importer_test.go
@@ -1,0 +1,81 @@
+package importer
+
+import (
+	"context"
+	"os"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFSImporter_Import(t *testing.T) {
+	// Create test filesystem with the bar.risor fixture
+	testFS := fstest.MapFS{
+		"foo/bar.risor": &fstest.MapFile{
+			Data: []byte(`
+func test_function() {
+    return 765
+}
+`),
+		},
+		"example.rriissoorr": &fstest.MapFile{
+			Data: []byte(`func hello() { return "world" }`),
+		},
+	}
+
+	t.Run("successfully imports existing module", func(t *testing.T) {
+		importer := NewFSImporter(FSImporterOptions{
+			SourceFS: testFS,
+		})
+
+		module, err := importer.Import(context.Background(), "foo/bar")
+		require.NoError(t, err)
+		require.NotNil(t, module)
+		require.Equal(t, "foo/bar", module.Name().Value())
+		require.NotNil(t, module.Code())
+
+		code := module.Code()
+		require.Equal(t, []string{"test_function"}, code.GlobalNames())
+	})
+
+	t.Run("returns error for nonexistent module", func(t *testing.T) {
+		importer := NewFSImporter(FSImporterOptions{
+			SourceFS: testFS,
+		})
+
+		module, err := importer.Import(context.Background(), "nonexistent")
+		require.Error(t, err)
+		require.Nil(t, module)
+		require.Contains(t, err.Error(), "module \"nonexistent\" not found")
+	})
+
+	t.Run("uses custom extensions", func(t *testing.T) {
+		importer := NewFSImporter(FSImporterOptions{
+			SourceFS:   testFS,
+			Extensions: []string{".rriissoorr"},
+		})
+
+		module, err := importer.Import(context.Background(), "example")
+		require.NoError(t, err)
+		require.NotNil(t, module)
+		require.Equal(t, "example", module.Name().Value())
+	})
+}
+
+func TestFSImporter_WithRealFixtures(t *testing.T) {
+	// Create FSImporter using the fixtures directory in the current directory
+	importer := NewFSImporter(FSImporterOptions{
+		SourceFS: os.DirFS("fixtures"),
+	})
+
+	// Import the bar module from fixtures
+	module, err := importer.Import(context.Background(), "foo/bar")
+	require.NoError(t, err)
+	require.NotNil(t, module)
+	require.Equal(t, "foo/bar", module.Name().Value())
+	require.NotNil(t, module.Code())
+
+	code := module.Code()
+	require.Equal(t, []string{"bar"}, code.GlobalNames())
+}

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestLocalImporter_Import(t *testing.T) {
-
 	t.Run("successfully imports existing module", func(t *testing.T) {
 		importer := NewLocalImporter(LocalImporterOptions{
 			SourceDir: "fixtures",

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -1,0 +1,49 @@
+package importer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalImporter_Import(t *testing.T) {
+
+	t.Run("successfully imports existing module", func(t *testing.T) {
+		importer := NewLocalImporter(LocalImporterOptions{
+			SourceDir: "fixtures",
+		})
+
+		module, err := importer.Import(context.Background(), "foo/bar")
+		require.NoError(t, err)
+		require.NotNil(t, module)
+		require.Equal(t, "foo/bar", module.Name().Value())
+		require.NotNil(t, module.Code())
+
+		code := module.Code()
+		require.Equal(t, []string{"bar"}, code.GlobalNames())
+	})
+
+	t.Run("returns error for nonexistent module", func(t *testing.T) {
+		importer := NewLocalImporter(LocalImporterOptions{
+			SourceDir: "fixtures",
+		})
+
+		module, err := importer.Import(context.Background(), "nonexistent")
+		require.Error(t, err)
+		require.Nil(t, module)
+		require.Contains(t, err.Error(), "module \"nonexistent\" not found")
+	})
+
+	t.Run("uses custom extensions", func(t *testing.T) {
+		importer := NewLocalImporter(LocalImporterOptions{
+			SourceDir:  "fixtures/foo",
+			Extensions: []string{".rriissoorr"},
+		})
+
+		module, err := importer.Import(context.Background(), "example")
+		require.NoError(t, err)
+		require.NotNil(t, module)
+		require.Equal(t, "example", module.Name().Value())
+	})
+}


### PR DESCRIPTION
The importer expects an object implementing fs.FS interface. The filesystem is used as a source to search for Risor modules.

LocalImporter was refactored to use FSImporter internally while maintaining the existing interface for backwards compatibility.