### PR TITLE
modules/errors: Add "is" function

### DIFF
--- a/modules/errors/errors.go
+++ b/modules/errors/errors.go
@@ -74,6 +74,21 @@ func As(ctx context.Context, args ...object.Object) object.Object {
 	return object.NewBool(errors.As(err.Value(), otherInst))
 }
 
+func Is(ctx context.Context, args ...object.Object) object.Object {
+	if len(args) != 2 {
+		return object.ArgsErrorf("args error: errors.is() takes exactly 2 arguments (%d given)", len(args))
+	}
+	err, typErr := object.AsError(args[0])
+	if typErr != nil {
+		return typErr
+	}
+	target, typErr := object.AsError(args[1])
+	if typErr != nil {
+		return typErr
+	}
+	return object.NewBool(errors.Is(err.Value(), target.Value()))
+}
+
 func Module() *object.Module {
 	return object.NewBuiltinsModule("errors", map[string]object.Object{
 		"new":        object.NewBuiltin("new", New),
@@ -81,5 +96,6 @@ func Module() *object.Module {
 		"eval_error": object.NewBuiltin("eval_error", EvalError),
 		"args_error": object.NewBuiltin("args_error", ArgsError),
 		"as":         object.NewBuiltin("as", As),
+		"is":         object.NewBuiltin("is", Is),
 	})
 }

--- a/modules/errors/errors.md
+++ b/modules/errors/errors.md
@@ -29,3 +29,16 @@ Returns a new error value with the given message.
 >>> err
 something went wrong
 ```
+
+### is
+
+```go filename="Function signature"
+is(err error, target error) bool
+```
+
+Reports whether error matches target error.
+
+```go filename="Example"
+>>> errors.is(err, os.err_not_exist)
+true
+```

--- a/modules/errors/errors_test.go
+++ b/modules/errors/errors_test.go
@@ -3,7 +3,6 @@ package errors
 import (
 	"context"
 	"errors"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -68,11 +67,15 @@ func TestErrorsAs(t *testing.T) {
 }
 
 func TestErrorsIs(t *testing.T) {
-	err1 := object.NewError(os.ErrNotExist)
-	err2 := object.NewError(os.ErrExist)
+	var (
+		ErrNotExist = errors.New("file does not exist")
+		ErrExist    = errors.New("file already exists")
+	)
+	err1 := object.NewError(ErrNotExist)
+	err2 := object.NewError(ErrExist)
 	err3 := New(context.Background(), object.NewString("test"))
-	require.Equal(t, object.True, Is(context.Background(), err1, object.NewError(os.ErrNotExist)))
-	require.Equal(t, object.True, Is(context.Background(), err2, object.NewError(os.ErrExist)))
-	require.Equal(t, object.False, Is(context.Background(), err2, object.NewError(os.ErrNotExist)))
+	require.Equal(t, object.True, Is(context.Background(), err1, object.NewError(ErrNotExist)))
+	require.Equal(t, object.True, Is(context.Background(), err2, object.NewError(ErrExist)))
+	require.Equal(t, object.False, Is(context.Background(), err2, object.NewError(ErrNotExist)))
 	require.Equal(t, object.True, Is(context.Background(), err3, err3))
 }

--- a/modules/errors/errors_test.go
+++ b/modules/errors/errors_test.go
@@ -3,6 +3,9 @@ package errors
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -78,4 +81,120 @@ func TestErrorsIs(t *testing.T) {
 	require.Equal(t, object.True, Is(context.Background(), err2, object.NewError(ErrExist)))
 	require.Equal(t, object.False, Is(context.Background(), err2, object.NewError(ErrNotExist)))
 	require.Equal(t, object.True, Is(context.Background(), err3, err3))
+}
+
+func TestErrorsIsWithWrappedErrors(t *testing.T) {
+	baseErr := errors.New("base error")
+	wrappedErr := fmt.Errorf("wrapped: %w", baseErr)
+
+	base := object.NewError(baseErr)
+	wrapped := object.NewError(wrappedErr)
+
+	// A wrapped error should match its base error
+	require.Equal(t, object.True, Is(context.Background(), wrapped, base))
+
+	// But base error should not match the wrapped error
+	require.Equal(t, object.False, Is(context.Background(), base, wrapped))
+}
+
+func TestErrorsIsInvalidArgs(t *testing.T) {
+	ctx := context.Background()
+	err := object.NewError(errors.New("test error"))
+
+	// First argument is not an error
+	result := Is(ctx, object.NewString("not an error"), err)
+	require.IsType(t, &object.Error{}, result)
+
+	// Second argument is not an error
+	result = Is(ctx, err, object.NewString("not an error"))
+	require.IsType(t, &object.Error{}, result)
+
+	// Wrong number of arguments
+	result = Is(ctx, err)
+	require.IsType(t, &object.Error{}, result)
+	errObj, ok := result.(*object.Error)
+	require.True(t, ok)
+	require.Contains(t, errObj.Value().Error(), "takes exactly 2 arguments")
+
+	result = Is(ctx, err, err, err)
+	require.IsType(t, &object.Error{}, result)
+	errObj, ok = result.(*object.Error)
+	require.True(t, ok)
+	require.Contains(t, errObj.Value().Error(), "takes exactly 2 arguments")
+}
+
+func TestErrorsIsSentinelErrors(t *testing.T) {
+	// Define custom sentinel errors
+	var (
+		ErrPermissionDenied = errors.New("permission denied")
+		ErrCustom           = errors.New("custom error")
+	)
+
+	// Create wrapper errors
+	permErr := fmt.Errorf("cannot access file: %w", ErrPermissionDenied)
+	deepWrapper := fmt.Errorf("operation failed: %w", permErr)
+
+	// Convert to Risor error objects
+	risorPermErr := object.NewError(permErr)
+	risorDeepWrapper := object.NewError(deepWrapper)
+	sentinelErr := object.NewError(ErrPermissionDenied)
+	otherErr := object.NewError(ErrCustom)
+
+	// Test error chain matching
+	require.Equal(t, object.True, Is(context.Background(), risorPermErr, sentinelErr))
+	require.Equal(t, object.True, Is(context.Background(), risorDeepWrapper, sentinelErr))
+	require.Equal(t, object.False, Is(context.Background(), risorPermErr, otherErr))
+	require.Equal(t, object.False, Is(context.Background(), risorDeepWrapper, otherErr))
+}
+
+func TestErrorsIsWithStdlibSentinels(t *testing.T) {
+	ctx := context.Background()
+
+	// Import standard sentinel errors from multiple stdlib packages
+	var (
+		// os package errors
+		errNotExist   = object.NewError(os.ErrNotExist)
+		errExist      = object.NewError(os.ErrExist)
+		errPermission = object.NewError(os.ErrPermission)
+
+		// io package errors
+		errEOF           = object.NewError(io.EOF)
+		errUnexpectedEOF = object.NewError(io.ErrUnexpectedEOF)
+
+		// context package errors
+		errCanceled         = object.NewError(context.Canceled)
+		errDeadlineExceeded = object.NewError(context.DeadlineExceeded)
+	)
+
+	// Create wrapped errors with stdlib sentinel errors
+	fileErr := fmt.Errorf("could not open file: %w", os.ErrNotExist)
+	readErr := fmt.Errorf("failed to read file: %w", io.EOF)
+	timeoutErr := fmt.Errorf("operation timed out: %w", context.DeadlineExceeded)
+
+	// Convert wrapped errors to Risor error objects
+	risorFileErr := object.NewError(fileErr)
+	risorReadErr := object.NewError(readErr)
+	risorTimeoutErr := object.NewError(timeoutErr)
+
+	// Test matching with stdlib sentinel errors
+	require.Equal(t, object.True, Is(ctx, risorFileErr, errNotExist))
+	require.Equal(t, object.False, Is(ctx, risorFileErr, errExist))
+	require.Equal(t, object.False, Is(ctx, risorFileErr, errPermission))
+
+	require.Equal(t, object.True, Is(ctx, risorReadErr, errEOF))
+	require.Equal(t, object.False, Is(ctx, risorReadErr, errUnexpectedEOF))
+
+	require.Equal(t, object.True, Is(ctx, risorTimeoutErr, errDeadlineExceeded))
+	require.Equal(t, object.False, Is(ctx, risorTimeoutErr, errCanceled))
+
+	// Test double-wrapped errors
+	deepFileErr := fmt.Errorf("data access error: %w", fileErr)
+	risorDeepFileErr := object.NewError(deepFileErr)
+	require.Equal(t, object.True, Is(ctx, risorDeepFileErr, errNotExist))
+
+	// Test combining multiple errors (only matches the wrapped one)
+	combinedErr := fmt.Errorf("multiple issues: %w and also EOF", os.ErrPermission)
+	risorCombinedErr := object.NewError(combinedErr)
+	require.Equal(t, object.True, Is(ctx, risorCombinedErr, errPermission))
+	require.Equal(t, object.False, Is(ctx, risorCombinedErr, errEOF))
 }

--- a/modules/errors/errors_test.go
+++ b/modules/errors/errors_test.go
@@ -3,11 +3,13 @@ package errors
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/risor-io/risor/errz"
 	"github.com/risor-io/risor/object"
-	"github.com/stretchr/testify/require"
 )
 
 func TestErrors(t *testing.T) {
@@ -63,4 +65,14 @@ func TestErrorsAs(t *testing.T) {
 	require.Equal(t, object.True, As(context.Background(), e1, evalErr))
 	require.Equal(t, object.False, As(context.Background(), e1, typeErr))
 	require.Equal(t, object.True, As(context.Background(), e1, genericErr))
+}
+
+func TestErrorsIs(t *testing.T) {
+	err1 := object.NewError(os.ErrNotExist)
+	err2 := object.NewError(os.ErrExist)
+	err3 := New(context.Background(), object.NewString("test"))
+	require.Equal(t, object.True, Is(context.Background(), err1, object.NewError(os.ErrNotExist)))
+	require.Equal(t, object.True, Is(context.Background(), err2, object.NewError(os.ErrExist)))
+	require.Equal(t, object.False, Is(context.Background(), err2, object.NewError(os.ErrNotExist)))
+	require.Equal(t, object.True, Is(context.Background(), err3, err3))
 }


### PR DESCRIPTION
The function wraps Go's `errors.Is`.