### PR TITLE
Make htmltomarkdown module callable

### DIFF
--- a/modules/htmltomarkdown/htmltomarkdown.go
+++ b/modules/htmltomarkdown/htmltomarkdown.go
@@ -25,5 +25,5 @@ func Convert(ctx context.Context, args ...object.Object) object.Object {
 func Module() *object.Module {
 	return object.NewBuiltinsModule("htmltomarkdown", map[string]object.Object{
 		"convert": object.NewBuiltin("convert", Convert),
-	})
+	}, Convert)
 }

--- a/modules/htmltomarkdown/htmltomarkdown.md
+++ b/modules/htmltomarkdown/htmltomarkdown.md
@@ -4,6 +4,16 @@ The `htmltomarkdown` module supports converting HTML to Markdown.
 
 This module uses the [html-to-markdown](https://github.com/JohannesKaufmann/html-to-markdown) Go library.
 
+## Module
+
+```go copy filename="Function signature"
+htmltomarkdown(html string) string
+```
+
+The `htmltomarkdown` module object itself is callable in order to provide a shorthand for converting HTML to Markdown:
+
+This is equivalent to calling `htmltomarkdown.convert()` with the same arguments.
+
 ## Functions
 
 ### convert

--- a/modules/htmltomarkdown/htmltomarkdown_test.go
+++ b/modules/htmltomarkdown/htmltomarkdown_test.go
@@ -54,3 +54,13 @@ func TestConvertInvalidArgs(t *testing.T) {
 	_, ok = result.(*object.Error)
 	assert.True(t, ok)
 }
+
+func TestCreateModule(t *testing.T) {
+	module := Module()
+	assert.NotNil(t, module)
+
+	convert, ok := module.GetAttr("convert")
+	assert.True(t, ok)
+	assert.NotNil(t, convert)
+	assert.IsType(t, &object.Builtin{}, convert)
+}


### PR DESCRIPTION
As a shorthand for `htmltomarkdown.convert`.