### PR TITLE
more release related nits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,8 @@ docker-build:
 	docker buildx build \
 		-t risor/risor:latest \
 		-t risor/risor:$(GIT_REVISION) \
-		-t risor/risor:1.8.0 \
-		--build-arg "RISOR_VERSION=1.8.0" \
+		-t risor/risor:1.8.1 \
+		--build-arg "RISOR_VERSION=1.8.1" \
 		--build-arg "GIT_REVISION=$(GIT_REVISION)" \
 		--build-arg "BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')" \
 		--platform linux/amd64,linux/arm64 \

--- a/cmd/risor/go.mod
+++ b/cmd/risor/go.mod
@@ -40,31 +40,31 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/risor-io/risor v1.8.0
-	github.com/risor-io/risor/modules/aws v1.8.0
-	github.com/risor-io/risor/modules/bcrypt v1.8.0
-	github.com/risor-io/risor/modules/cli v1.8.0
+	github.com/risor-io/risor/modules/aws v0.0.0-00010101000000-000000000000
+	github.com/risor-io/risor/modules/bcrypt v0.0.0-00010101000000-000000000000
+	github.com/risor-io/risor/modules/cli v0.0.0-00010101000000-000000000000
 	github.com/risor-io/risor/modules/color v0.0.0-00010101000000-000000000000
-	github.com/risor-io/risor/modules/gha v1.8.0
+	github.com/risor-io/risor/modules/gha v0.0.0-00010101000000-000000000000
 	github.com/risor-io/risor/modules/goquery v0.0.0-00010101000000-000000000000
 	github.com/risor-io/risor/modules/htmltomarkdown v0.0.0-00010101000000-000000000000
-	github.com/risor-io/risor/modules/image v1.8.0
+	github.com/risor-io/risor/modules/image v0.0.0-00010101000000-000000000000
 	github.com/risor-io/risor/modules/isatty v0.0.0-00010101000000-000000000000
-	github.com/risor-io/risor/modules/jmespath v1.8.0
-	github.com/risor-io/risor/modules/kubernetes v1.8.0
-	github.com/risor-io/risor/modules/pgx v1.8.0
+	github.com/risor-io/risor/modules/jmespath v0.0.0-00010101000000-000000000000
+	github.com/risor-io/risor/modules/kubernetes v0.0.0-00010101000000-000000000000
+	github.com/risor-io/risor/modules/pgx v0.0.0-00010101000000-000000000000
 	github.com/risor-io/risor/modules/playwright v0.0.0-00010101000000-000000000000
 	github.com/risor-io/risor/modules/qrcode v0.0.0-00010101000000-000000000000
-	github.com/risor-io/risor/modules/sched v1.8.0
-	github.com/risor-io/risor/modules/semver v1.8.0
-	github.com/risor-io/risor/modules/shlex v1.8.0
+	github.com/risor-io/risor/modules/sched v0.0.0-00010101000000-000000000000
+	github.com/risor-io/risor/modules/semver v0.0.0-00010101000000-000000000000
+	github.com/risor-io/risor/modules/shlex v0.0.0-00010101000000-000000000000
 	github.com/risor-io/risor/modules/slack v0.0.0-00010101000000-000000000000
-	github.com/risor-io/risor/modules/sql v1.8.0
+	github.com/risor-io/risor/modules/sql v0.0.0-00010101000000-000000000000
 	github.com/risor-io/risor/modules/tablewriter v0.0.0-00010101000000-000000000000
-	github.com/risor-io/risor/modules/template v1.8.0
-	github.com/risor-io/risor/modules/uuid v1.8.0
-	github.com/risor-io/risor/modules/vault v1.8.0
+	github.com/risor-io/risor/modules/template v0.0.0-00010101000000-000000000000
+	github.com/risor-io/risor/modules/uuid v0.0.0-00010101000000-000000000000
+	github.com/risor-io/risor/modules/vault v0.0.0-00010101000000-000000000000
 	github.com/risor-io/risor/modules/yaml v0.0.0-00010101000000-000000000000
-	github.com/risor-io/risor/os/s3fs v1.8.0
+	github.com/risor-io/risor/os/s3fs v0.0.0-00010101000000-000000000000
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0

--- a/examples/go/sqlite/go.mod
+++ b/examples/go/sqlite/go.mod
@@ -2,13 +2,14 @@ module github.com/risor-io/risor/examples/go/sqlite
 
 go 1.23.0
 
-replace github.com/risor-io/risor => ../../..
-
-replace github.com/risor-io/risor/modules/sql => ../../../modules/sql
+replace (
+	github.com/risor-io/risor => ../../..
+	github.com/risor-io/risor/modules/sql => ../../../modules/sql
+)
 
 require (
 	github.com/mattn/go-sqlite3 v1.14.28
-	github.com/risor-io/risor v1.7.0
+	github.com/risor-io/risor v1.8.0
 	github.com/risor-io/risor/modules/sql v0.0.0-00010101000000-000000000000
 )
 

--- a/examples/go/struct/go.mod
+++ b/examples/go/struct/go.mod
@@ -6,7 +6,7 @@ replace github.com/risor-io/risor => ../../..
 
 require (
 	github.com/fatih/color v1.18.0
-	github.com/risor-io/risor v1.7.0
+	github.com/risor-io/risor v0.0.0-00010101000000-000000000000
 )
 
 require (

--- a/examples/go/tetra3d/go.mod
+++ b/examples/go/tetra3d/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 replace github.com/risor-io/risor => ../../..
 
 require (
-	github.com/risor-io/risor v1.7.0
+	github.com/risor-io/risor v0.0.0-00010101000000-000000000000
 	github.com/solarlune/tetra3d v0.16.3
 )
 


### PR DESCRIPTION
Started this branch to update the go.mod files in the `examples/` subdirectory.

But also did a couple other minor things while at it.

Trying out the `v0.0.0-00010101000000-000000000000` version in some places. Oddly `go mod tidy` switches it to `v1.8.0` in examples/go/sqlite/go.mod but not in the other examples. Hard to know if that's just some weird edge case with go mod tidy or what.

fyi @rubiojr 



