### PR TITLE
Add risor.DefaultGlobals function

### DIFF
--- a/modules/all/all.go
+++ b/modules/all/all.go
@@ -1,56 +1,22 @@
 package all
 
 import (
-	"github.com/risor-io/risor/builtins"
-	modBase64 "github.com/risor-io/risor/modules/base64"
-	modBytes "github.com/risor-io/risor/modules/bytes"
-	modErrors "github.com/risor-io/risor/modules/errors"
-	modExec "github.com/risor-io/risor/modules/exec"
-	modFilepath "github.com/risor-io/risor/modules/filepath"
-	modFmt "github.com/risor-io/risor/modules/fmt"
-	modHTTP "github.com/risor-io/risor/modules/http"
-	modJSON "github.com/risor-io/risor/modules/json"
-	modMath "github.com/risor-io/risor/modules/math"
-	modNet "github.com/risor-io/risor/modules/net"
-	modOs "github.com/risor-io/risor/modules/os"
-	modRand "github.com/risor-io/risor/modules/rand"
-	modRegexp "github.com/risor-io/risor/modules/regexp"
-	modStrconv "github.com/risor-io/risor/modules/strconv"
-	modStrings "github.com/risor-io/risor/modules/strings"
-	modTime "github.com/risor-io/risor/modules/time"
+	"github.com/risor-io/risor"
 	"github.com/risor-io/risor/object"
 )
 
+// Builtins returns a map of standard builtins and globals for Risor scripts.
+// This includes only the builtins and modules that are always available, without
+// pulling in additional Go modules.
+//
+// Deprecated: Use risor.DefaultGlobals instead.
 func Builtins() map[string]object.Object {
-	result := map[string]object.Object{
-		"base64":   modBase64.Module(),
-		"bytes":    modBytes.Module(),
-		"errors":   modErrors.Module(),
-		"exec":     modExec.Module(),
-		"filepath": modFilepath.Module(),
-		"fmt":      modFmt.Module(),
-		"http":     modHTTP.Module(),
-		"json":     modJSON.Module(),
-		"math":     modMath.Module(),
-		"net":      modNet.Module(),
-		"os":       modOs.Module(),
-		"rand":     modRand.Module(),
-		"regexp":   modRegexp.Module(),
-		"strconv":  modStrconv.Module(),
-		"strings":  modStrings.Module(),
-		"time":     modTime.Module(),
-	}
-	for k, v := range modHTTP.Builtins() {
-		result[k] = v
-	}
-	for k, v := range modFmt.Builtins() {
-		result[k] = v
-	}
-	for k, v := range builtins.Builtins() {
-		result[k] = v
-	}
-	for k, v := range modOs.Builtins() {
-		result[k] = v
+	globals := risor.DefaultGlobals(risor.DefaultGlobalsOpts{
+		ListenersAllowed: true,
+	})
+	result := map[string]object.Object{}
+	for k, v := range globals {
+		result[k] = v.(object.Object)
 	}
 	return result
 }

--- a/risor_config.go
+++ b/risor_config.go
@@ -5,25 +5,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/risor-io/risor/builtins"
 	"github.com/risor-io/risor/compiler"
 	"github.com/risor-io/risor/importer"
-	modBase64 "github.com/risor-io/risor/modules/base64"
-	modBytes "github.com/risor-io/risor/modules/bytes"
-	modDns "github.com/risor-io/risor/modules/dns"
-	modErrors "github.com/risor-io/risor/modules/errors"
-	modExec "github.com/risor-io/risor/modules/exec"
-	modFilepath "github.com/risor-io/risor/modules/filepath"
-	modFmt "github.com/risor-io/risor/modules/fmt"
-	modHTTP "github.com/risor-io/risor/modules/http"
-	modJSON "github.com/risor-io/risor/modules/json"
-	modMath "github.com/risor-io/risor/modules/math"
-	modOs "github.com/risor-io/risor/modules/os"
-	modRand "github.com/risor-io/risor/modules/rand"
-	modRegexp "github.com/risor-io/risor/modules/regexp"
-	modStrconv "github.com/risor-io/risor/modules/strconv"
-	modStrings "github.com/risor-io/risor/modules/strings"
-	modTime "github.com/risor-io/risor/modules/time"
 	"github.com/risor-io/risor/object"
 	"github.com/risor-io/risor/os"
 	"github.com/risor-io/risor/vm"
@@ -115,38 +98,9 @@ func (cfg *Config) applyDefaultGlobals() {
 	if cfg.withoutDefaultGlobals {
 		return
 	}
-	// Add default builtin functions as globals
-	moduleBuiltins := []map[string]object.Object{
-		builtins.Builtins(),
-		modHTTP.Builtins(),
-		modFmt.Builtins(),
-		modOs.Builtins(),
-		modDns.Builtins(),
-	}
-	for _, builtins := range moduleBuiltins {
-		for k, v := range builtins {
-			cfg.globals[k] = v
-		}
-	}
-	// Add default modules as globals
-	modules := map[string]object.Object{
-		"base64":   modBase64.Module(),
-		"bytes":    modBytes.Module(),
-		"errors":   modErrors.Module(),
-		"exec":     modExec.Module(),
-		"filepath": modFilepath.Module(),
-		"fmt":      modFmt.Module(),
-		"http":     modHTTP.Module(modHTTP.ModuleOpts{ListenersAllowed: cfg.listenersAllowed}),
-		"json":     modJSON.Module(),
-		"math":     modMath.Module(),
-		"os":       modOs.Module(),
-		"rand":     modRand.Module(),
-		"regexp":   modRegexp.Module(),
-		"strconv":  modStrconv.Module(),
-		"strings":  modStrings.Module(),
-		"time":     modTime.Module(),
-	}
-	for k, v := range modules {
+	for k, v := range DefaultGlobals(DefaultGlobalsOpts{
+		ListenersAllowed: cfg.listenersAllowed,
+	}) {
 		cfg.globals[k] = v
 	}
 }

--- a/risor_globals.go
+++ b/risor_globals.go
@@ -1,0 +1,79 @@
+package risor
+
+import (
+	"github.com/risor-io/risor/builtins"
+	modBase64 "github.com/risor-io/risor/modules/base64"
+	modBytes "github.com/risor-io/risor/modules/bytes"
+	modDns "github.com/risor-io/risor/modules/dns"
+	modErrors "github.com/risor-io/risor/modules/errors"
+	modExec "github.com/risor-io/risor/modules/exec"
+	modFilepath "github.com/risor-io/risor/modules/filepath"
+	modFmt "github.com/risor-io/risor/modules/fmt"
+	modHTTP "github.com/risor-io/risor/modules/http"
+	modJSON "github.com/risor-io/risor/modules/json"
+	modMath "github.com/risor-io/risor/modules/math"
+	modNet "github.com/risor-io/risor/modules/net"
+	modOs "github.com/risor-io/risor/modules/os"
+	modRand "github.com/risor-io/risor/modules/rand"
+	modRegexp "github.com/risor-io/risor/modules/regexp"
+	modStrconv "github.com/risor-io/risor/modules/strconv"
+	modStrings "github.com/risor-io/risor/modules/strings"
+	modTime "github.com/risor-io/risor/modules/time"
+	"github.com/risor-io/risor/object"
+)
+
+// DefaultGlobalsOpts are options for the DefaultGlobals function.
+type DefaultGlobalsOpts struct {
+	ListenersAllowed bool
+}
+
+// DefaultGlobals returns a map of standard globals for Risor scripts. This
+// includes only the builtins and modules that are always available, without
+// pulling in additional Go modules.
+func DefaultGlobals(opts ...DefaultGlobalsOpts) map[string]any {
+	var opt DefaultGlobalsOpts
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	globals := map[string]any{}
+
+	// Add default builtin functions as globals
+	moduleBuiltins := []map[string]object.Object{
+		builtins.Builtins(),
+		modHTTP.Builtins(),
+		modFmt.Builtins(),
+		modOs.Builtins(),
+		modDns.Builtins(),
+	}
+	for _, builtins := range moduleBuiltins {
+		for k, v := range builtins {
+			globals[k] = v
+		}
+	}
+
+	// Add default modules as globals
+	modules := map[string]object.Object{
+		"base64":   modBase64.Module(),
+		"bytes":    modBytes.Module(),
+		"errors":   modErrors.Module(),
+		"exec":     modExec.Module(),
+		"filepath": modFilepath.Module(),
+		"fmt":      modFmt.Module(),
+		"http":     modHTTP.Module(modHTTP.ModuleOpts{ListenersAllowed: opt.ListenersAllowed}),
+		"json":     modJSON.Module(),
+		"math":     modMath.Module(),
+		"net":      modNet.Module(),
+		"os":       modOs.Module(),
+		"rand":     modRand.Module(),
+		"regexp":   modRegexp.Module(),
+		"strconv":  modStrconv.Module(),
+		"strings":  modStrings.Module(),
+		"time":     modTime.Module(),
+	}
+	for k, v := range modules {
+		globals[k] = v
+	}
+
+	return globals
+}

--- a/risor_test.go
+++ b/risor_test.go
@@ -418,3 +418,25 @@ func TestWithExistingVM(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, int64(4), result.Interface())
 }
+
+func TestDefaultGlobalsFunc(t *testing.T) {
+	globals := DefaultGlobals(DefaultGlobalsOpts{
+		ListenersAllowed: true,
+	})
+	expectedNames := []string{ // non-exhaustive
+		"base64",
+		"bytes",
+		"errors",
+		"exec",
+		"filepath",
+		"fmt",
+		"http",
+		"cat",
+		"ls",
+		"print",
+	}
+	for _, name := range expectedNames {
+		_, ok := globals[name]
+		require.True(t, ok, "expected global %s", name)
+	}
+}


### PR DESCRIPTION
Usage:

```go
// No options
globals := DefaultGlobals()

// For any configuration, right now just opts into allowing HTTP listeners
globals := DefaultGlobals(DefaultGlobalsOpts{
	ListenersAllowed: true,
})
```

This makes default globals more easily reproducible in user programs.


