### PR TITLE
Add stderr to Risor's os module

### DIFF
--- a/modules/os/os.go
+++ b/modules/os/os.go
@@ -626,6 +626,10 @@ func Module() *object.Module {
 			f := GetOS(ctx).Stdout()
 			return object.NewFile(ctx, f, "/dev/stdout"), nil
 		}),
+		"stderr": object.NewDynamicAttr("stderr", func(ctx context.Context, name string) (object.Object, error) {
+			f := GetOS(ctx).Stderr()
+			return object.NewFile(ctx, f, "/dev/stderr"), nil
+		}),
 		"err_not_exist":         object.NewError(goos.ErrNotExist).WithRaised(false),
 		"err_exist":             object.NewError(goos.ErrExist).WithRaised(false),
 		"err_permission":        object.NewError(goos.ErrPermission).WithRaised(false),

--- a/modules/os/os_test.go
+++ b/modules/os/os_test.go
@@ -1,0 +1,55 @@
+package os
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/risor-io/risor/object"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStdio(t *testing.T) {
+	m := Module()
+
+	type testCase struct {
+		name     string
+		attr     string
+		expected *os.File
+	}
+
+	tests := []testCase{
+		{
+			name:     "stdin",
+			attr:     "stdin",
+			expected: os.Stdin,
+		},
+		{
+			name:     "stdout",
+			attr:     "stdout",
+			expected: os.Stdout,
+		},
+		{
+			name:     "stderr",
+			attr:     "stderr",
+			expected: os.Stderr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attr, ok := m.GetAttr(tt.attr)
+			require.True(t, ok)
+
+			stdin, ok := attr.(*object.DynamicAttr)
+			require.True(t, ok)
+
+			result, err := stdin.ResolveAttr(context.Background(), "")
+			require.NoError(t, err)
+
+			file, ok := result.(*object.File)
+			require.True(t, ok)
+			require.Equal(t, tt.expected, file.Value())
+		})
+	}
+}

--- a/os/os.go
+++ b/os/os.go
@@ -97,6 +97,7 @@ type OS interface {
 	UserHomeDir() (string, error)
 	Stdin() File
 	Stdout() File
+	Stderr() File
 	PathSeparator() rune
 	PathListSeparator() rune
 	CurrentUser() (User, error)

--- a/os/simple.go
+++ b/os/simple.go
@@ -143,6 +143,10 @@ func (osObj *SimpleOS) Stdout() File {
 	return os.Stdout
 }
 
+func (osObj *SimpleOS) Stderr() File {
+	return os.Stderr
+}
+
 func (osObj *SimpleOS) ReadDir(name string) ([]DirEntry, error) {
 	results, err := os.ReadDir(name)
 	if err != nil {

--- a/os/virtual.go
+++ b/os/virtual.go
@@ -77,6 +77,7 @@ type VirtualOS struct {
 	exitHandler   ExitHandler
 	stdin         File
 	stdout        File
+	stderr        File
 	args          []string
 	currentUser   *VirtualUser
 	users         map[string]*VirtualUser  // by username
@@ -190,6 +191,13 @@ func WithStdout(stdout File) Option {
 	}
 }
 
+// WithStderr sets the stderr.
+func WithStderr(stderr File) Option {
+	return func(vos *VirtualOS) {
+		vos.stderr = stderr
+	}
+}
+
 // WithCurrentUser sets the current user.
 func WithCurrentUser(user *VirtualUser) Option {
 	return func(vos *VirtualOS) {
@@ -225,6 +233,7 @@ func NewVirtualOS(ctx context.Context, opts ...Option) *VirtualOS {
 		cwd:         "/",
 		stdin:       &NilFile{},
 		stdout:      &NilFile{},
+		stderr:      &NilFile{},
 		users:       map[string]*VirtualUser{},
 		usersByUid:  map[string]*VirtualUser{},
 		groups:      map[string]*VirtualGroup{},
@@ -513,6 +522,10 @@ func (osObj *VirtualOS) Stdin() File {
 
 func (osObj *VirtualOS) Stdout() File {
 	return osObj.stdout
+}
+
+func (osObj *VirtualOS) Stderr() File {
+	return osObj.stderr
 }
 
 func (osObj *VirtualOS) PathSeparator() rune {

--- a/os/virtual_test.go
+++ b/os/virtual_test.go
@@ -161,10 +161,12 @@ func TestVirtualOSStdIO(t *testing.T) {
 	ctx := context.Background()
 	stdin := &InMemoryFile{name: "stdin", data: []byte("test input")}
 	stdout := &InMemoryFile{name: "stdout"}
+	stderr := &InMemoryFile{name: "stderr"}
 
 	vos := NewVirtualOS(ctx,
 		WithStdin(stdin),
 		WithStdout(stdout),
+		WithStderr(stderr),
 	)
 
 	// Instead of comparing the File objects directly, we verify stdin by reading from it
@@ -191,6 +193,22 @@ func TestVirtualOSStdIO(t *testing.T) {
 	stdoutContents := stdout.data
 	if string(stdoutContents) != "test output" {
 		t.Errorf("Expected stdout contents to be 'test output', got '%s'", string(stdoutContents))
+	}
+
+	// Verify stderr by writing to it and checking the underlying memory file
+	stderrFile := vos.Stderr()
+	n, err = stderrFile.Write([]byte("test error"))
+	if err != nil {
+		t.Errorf("Writing to stderr failed: %v", err)
+	}
+	if n != 10 {
+		t.Errorf("Expected to write 10 bytes to stderr, wrote %d", n)
+	}
+
+	// Verify stderr contents
+	stderrContents := stderr.data
+	if string(stderrContents) != "test error" {
+		t.Errorf("Expected stderr contents to be 'test error', got '%s'", string(stderrContents))
 	}
 }
 


### PR DESCRIPTION
Add `os.stderr` to Risor's `os` module to provide access to the standard error stream.