### PR TITLE
Investigate k8s apply manifest error

### DIFF
--- a/go.work
+++ b/go.work
@@ -22,6 +22,7 @@ use (
 	./modules/image
 	./modules/isatty
 	./modules/jmespath
+	./modules/kubernetes
 	./modules/pgx
 	./modules/playwright
 	./modules/qrcode

--- a/modules/kubernetes/k8s.go
+++ b/modules/kubernetes/k8s.go
@@ -358,7 +358,7 @@ func Apply(ctx context.Context, args ...object.Object) object.Object {
 		return object.NewError(err)
 	}
 
-	return object.FromGoType(op)
+	return object.FromGoType(string(op))
 }
 
 //go:embed kubernetes.md


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix `k8s.apply` returning a type error by explicitly converting its operation result to a string.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `object.FromGoType` function did not correctly handle `controllerutil.OperationResult` (a named string type), causing a `TypeErrorf` instead of returning the expected operation result string. Explicitly casting it to a `string` resolves this unmarshaling error. Also, adds the `kubernetes` module to `go.work` for proper workspace integration.

---

[Open in Web](https://cursor.com/agents?id=bc-928a4bd7-9951-4da6-bf0f-926663f6c273) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-928a4bd7-9951-4da6-bf0f-926663f6c273) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)