### PR TITLE
Add not keyword for membership tests

### DIFF
--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -565,6 +565,38 @@ func (i *In) String() string {
 	return out.String()
 }
 
+// NotIn is an expression node that checks whether a value is NOT present in a container.
+type NotIn struct {
+	token token.Token
+	left  Expression
+	right Expression
+}
+
+// NewNotIn creates a new NotIn node.
+func NewNotIn(token token.Token, left Expression, right Expression) *NotIn {
+	return &NotIn{token: token, left: left, right: right}
+}
+
+func (n *NotIn) ExpressionNode() {}
+
+func (n *NotIn) IsExpression() bool { return true }
+
+func (n *NotIn) Token() token.Token { return n.token }
+
+func (n *NotIn) Literal() string { return n.token.Literal }
+
+func (n *NotIn) Left() Expression { return n.left }
+
+func (n *NotIn) Right() Expression { return n.right }
+
+func (n *NotIn) String() string {
+	var out bytes.Buffer
+	out.WriteString(n.left.String())
+	out.WriteString(" not in ")
+	out.WriteString(n.right.String())
+	return out.String()
+}
+
 // Range is an expression node that describes iterating over a container.
 type Range struct {
 	// the "range" token

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -281,6 +281,10 @@ func (c *Compiler) compile(node ast.Node) error {
 		if err := c.compileIn(node); err != nil {
 			return err
 		}
+	case *ast.NotIn:
+		if err := c.compileNotIn(node); err != nil {
+			return err
+		}
 	case *ast.Const:
 		if err := c.compileConst(node); err != nil {
 			return err
@@ -918,6 +922,18 @@ func (c *Compiler) compileIn(node *ast.In) error {
 		return err
 	}
 	c.emit(op.ContainsOp, 0)
+	return nil
+}
+
+func (c *Compiler) compileNotIn(node *ast.NotIn) error {
+	if err := c.compile(node.Right()); err != nil {
+		return err
+	}
+	if err := c.compile(node.Left()); err != nil {
+		return err
+	}
+	c.emit(op.ContainsOp, 0)
+	c.emit(op.UnaryNot)
 	return nil
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1581,39 +1581,37 @@ func (p *Parser) parseIn(leftNode ast.Node) ast.Node {
 	return ast.NewIn(inToken, left, right)
 }
 
-
-
 func (p *Parser) parseNotIn(leftNode ast.Node) ast.Node {
 	left, ok := leftNode.(ast.Expression)
 	if !ok {
 		p.setTokenError(p.curToken, "invalid not in expression")
 		return nil
 	}
-	
+
 	notToken := p.curToken
-	
+
 	// Check if the next token is IN
 	if !p.peekTokenIs(token.IN) {
 		p.setTokenError(p.peekToken, "expected 'in' after 'not' (got %s)", p.peekToken.Literal)
 		return nil
 	}
-	
+
 	// Move to the IN token
 	if err := p.nextToken(); err != nil {
 		return nil
 	}
-	
+
 	// Move past the IN token to parse the right operand
 	if err := p.nextToken(); err != nil {
 		return nil
 	}
-	
+
 	right := p.parseExpression(PREFIX)
 	if right == nil {
 		p.setTokenError(p.curToken, "invalid not in expression")
 		return nil
 	}
-	
+
 	return ast.NewNotIn(notToken, left, right)
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -814,6 +814,18 @@ func TestIn(t *testing.T) {
 	require.Equal(t, "x in [1, 2]", node.String())
 }
 
+func TestNotIn(t *testing.T) {
+	program, err := Parse(context.Background(), "x not in [1, 2]")
+	require.Nil(t, err)
+	require.Len(t, program.Statements(), 1)
+	node, ok := program.First().(*ast.NotIn)
+	require.True(t, ok)
+	require.Equal(t, "not", node.Literal())
+	require.Equal(t, "x", node.Left().String())
+	require.Equal(t, "[1, 2]", node.Right().String())
+	require.Equal(t, "x not in [1, 2]", node.String())
+}
+
 func TestBreak(t *testing.T) {
 	program, err := Parse(context.Background(), "break")
 	require.Nil(t, err)
@@ -1017,6 +1029,25 @@ func TestInPrecedence(t *testing.T) {
 
 	require.Equal(t, "2", inStmt.Left().String())
 	require.Equal(t, "float_slice([1, 2, 3])", inStmt.Right().String())
+}
+
+func TestNotInPrecedence(t *testing.T) {
+	// This confirms the correct precedence of the "not in" vs. "call" operators
+	input := `2 not in float_slice([1,2,3])`
+
+	// Parse the program, which should be 1 statement in length
+	program, err := Parse(context.Background(), input)
+	require.Nil(t, err)
+	require.Len(t, program.Statements(), 1)
+	stmt := program.First()
+
+	// The top-level of the AST should be a not in statement
+	require.IsType(t, &ast.NotIn{}, stmt)
+	notInStmt := stmt.(*ast.NotIn)
+	fmt.Println(notInStmt.String())
+
+	require.Equal(t, "2", notInStmt.Left().String())
+	require.Equal(t, "float_slice([1, 2, 3])", notInStmt.Right().String())
 }
 
 func TestNakedReturns(t *testing.T) {

--- a/parser/precedence.go
+++ b/parser/precedence.go
@@ -54,6 +54,7 @@ var precedences = map[token.Type]int{
 	token.PERIOD:          INDEX,
 	token.LBRACKET:        INDEX,
 	token.IN:              PREFIX,
+	token.NOT:             PREFIX,
 	token.RANGE:           PREFIX,
 	token.SEND:            CALL,
 }

--- a/tests/test-comprehensive-not-in.tm
+++ b/tests/test-comprehensive-not-in.tm
@@ -1,0 +1,9 @@
+// Comprehensive test for "not in" operator - addresses original feature request
+// expected value: true
+// expected type: bool
+
+// Original feature request: "It's kind of awkward to do if !("element" in map) { } 
+// when checking to see if a key exists in a map. I think it would feel a bit more 
+// natural to have not for maps"
+
+"element" not in {"key1": "value1", "key2": "value2"}

--- a/tests/test-equivalence-check.tm
+++ b/tests/test-equivalence-check.tm
@@ -1,0 +1,6 @@
+// Test equivalence: "not in" should equal !("element" in container)
+// expected value: true
+// expected type: bool
+
+// Both expressions should evaluate to the same result
+("element" not in {"key": "value"}) == !("element" in {"key": "value"})

--- a/tests/test-feature-demo.tm
+++ b/tests/test-feature-demo.tm
@@ -1,0 +1,8 @@
+// Demonstration of the new "not in" feature
+// This replaces the awkward !("element" in map) syntax
+// expected value: true  
+// expected type: bool
+
+// Before: !("element" in {"key": "value"})
+// Now: "element" not in {"key": "value"}
+"element" not in {"key": "value", "another": "test"}

--- a/tests/test-not-in-operator-map.tm
+++ b/tests/test-not-in-operator-map.tm
@@ -1,0 +1,6 @@
+// Test for "not in" operator with maps
+// expected value: true
+// expected type: bool
+
+// Test "not in" with map - this addresses the original feature request
+"element" not in {"key": "value", "another": "test"}

--- a/tests/test-not-in-operator-true.tm
+++ b/tests/test-not-in-operator-true.tm
@@ -1,0 +1,6 @@
+// Test for "not in" operator functionality - true case
+// expected value: true
+// expected type: bool
+
+// Test "not in" with element not in list
+"d" not in ["a", "b", "c"]

--- a/tests/test-not-in-operator.tm
+++ b/tests/test-not-in-operator.tm
@@ -1,0 +1,6 @@
+// Test for "not in" operator functionality
+// expected value: false
+// expected type: bool
+
+// Test basic "not in" with list
+"a" not in ["a", "b", "c"]

--- a/tests/test-not-in-precedence.tm
+++ b/tests/test-not-in-precedence.tm
@@ -1,0 +1,6 @@
+// Test for "not in" operator precedence
+// expected value: true
+// expected type: bool
+
+// Test "not in" with logical AND - should be: (2 not in [1,3]) && true
+2 not in [1, 3] && true

--- a/token/token.go
+++ b/token/token.go
@@ -75,6 +75,7 @@ const (
 	MOD             = "%"
 	NOT_EQ          = "!="
 	NIL             = "nil"
+	NOT             = "NOT"
 	PIPE            = "|"
 	OR              = "||"
 	PERIOD          = "."
@@ -126,6 +127,7 @@ var keywords = map[string]Type{
 	"import":   IMPORT,
 	"in":       IN,
 	"nil":      NIL,
+	"not":      NOT,
 	"range":    RANGE,
 	"return":   RETURN,
 	"struct":   STRUCT,


### PR DESCRIPTION
Add support for the `not in` operator to provide a more natural and readable syntax for checking non-membership in containers.

---
<a href="https://cursor.com/background-agent?bcId=bc-03e54f45-f7f5-49fc-ba94-d3e48c5842cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-03e54f45-f7f5-49fc-ba94-d3e48c5842cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>