### PR TITLE
Add python style iteration support

### DIFF
--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -31,7 +31,7 @@ func TestForInNode(t *testing.T) {
 	// Create tokens
 	forToken := token.Token{Type: token.FOR, Literal: "for"}
 	identToken := token.Token{Type: token.IDENT, Literal: "x"}
-	
+
 	// Create AST nodes
 	variable := NewIdent(identToken)
 	iterable := NewIdent(token.Token{Type: token.IDENT, Literal: "items"})
@@ -41,35 +41,35 @@ func TestForInNode(t *testing.T) {
 			NewIdent(token.Token{Type: token.IDENT, Literal: "print"}),
 		},
 	}
-	
+
 	// Create ForIn node
 	forIn := NewForIn(forToken, variable, iterable, block)
-	
+
 	// Test all methods
 	if forIn.Token().Type != token.FOR {
 		t.Errorf("forIn.Token().Type wrong. got=%s", forIn.Token().Type)
 	}
-	
+
 	if forIn.Literal() != "for" {
 		t.Errorf("forIn.Literal() wrong. got=%s", forIn.Literal())
 	}
-	
+
 	if forIn.IsExpression() != false {
 		t.Errorf("forIn.IsExpression() wrong. got=%t", forIn.IsExpression())
 	}
-	
+
 	if forIn.Variable().Literal() != "x" {
 		t.Errorf("forIn.Variable().Literal() wrong. got=%s", forIn.Variable().Literal())
 	}
-	
+
 	if forIn.Iterable().String() != "items" {
 		t.Errorf("forIn.Iterable().String() wrong. got=%s", forIn.Iterable().String())
 	}
-	
+
 	if forIn.Consequence() == nil {
 		t.Error("forIn.Consequence() should not be nil")
 	}
-	
+
 	expected := "for x in items print"
 	if forIn.String() != expected {
 		t.Errorf("forIn.String() wrong. got=%q, expected=%q", forIn.String(), expected)
@@ -79,10 +79,10 @@ func TestForInNode(t *testing.T) {
 func TestForInNodeComplexCase(t *testing.T) {
 	// Test with more complex expressions
 	forToken := token.Token{Type: token.FOR, Literal: "for"}
-	
+
 	// Variable
 	variable := NewIdent(token.Token{Type: token.IDENT, Literal: "item"})
-	
+
 	// Complex iterable (list literal)
 	list := &List{
 		token: token.Token{Type: token.LBRACKET, Literal: "["},
@@ -92,13 +92,13 @@ func TestForInNodeComplexCase(t *testing.T) {
 			&Int{token: token.Token{Type: token.INT, Literal: "3"}, value: 3},
 		},
 	}
-	
+
 	// Block with multiple statements
 	block := &Block{
 		token: token.Token{Type: token.LBRACE, Literal: "{"},
 		statements: []Node{
 			&Call{
-				token: token.Token{Type: token.IDENT, Literal: "print"},
+				token:    token.Token{Type: token.IDENT, Literal: "print"},
 				function: NewIdent(token.Token{Type: token.IDENT, Literal: "print"}),
 				arguments: []Node{
 					NewIdent(token.Token{Type: token.IDENT, Literal: "item"}),
@@ -106,9 +106,9 @@ func TestForInNodeComplexCase(t *testing.T) {
 			},
 		},
 	}
-	
+
 	forIn := NewForIn(forToken, variable, list, block)
-	
+
 	// Test String output
 	result := forIn.String()
 	if !contains(result, "for item in") {
@@ -125,18 +125,18 @@ func TestForInNodeMethods(t *testing.T) {
 	variable := NewIdent(token.Token{Type: token.IDENT, Literal: "x"})
 	iterable := NewIdent(token.Token{Type: token.IDENT, Literal: "items"})
 	block := &Block{token: token.Token{Type: token.LBRACE, Literal: "{"}}
-	
+
 	forIn := NewForIn(forToken, variable, iterable, block)
-	
+
 	// Test that it implements Node interface
 	var node Node = forIn
 	if node.Token().Type != token.FOR {
 		t.Errorf("ForIn should implement Node interface correctly")
 	}
-	
+
 	// Test StatementNode method (should not panic)
 	forIn.StatementNode()
-	
+
 	// Test that all accessors work
 	if forIn.Variable() != variable {
 		t.Errorf("Variable() should return the correct variable")
@@ -151,8 +151,8 @@ func TestForInNodeMethods(t *testing.T) {
 
 // Helper function for string containment check
 func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || 
-		(len(s) > len(substr) && 
+	return len(s) >= len(substr) && (s == substr ||
+		(len(s) > len(substr) &&
 			(s[:len(substr)] == substr ||
 				s[len(s)-len(substr):] == substr ||
 				containsAt(s, substr))))

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -26,3 +26,143 @@ func TestString(t *testing.T) {
 		t.Errorf("program.String() wrong. got=%q", program.String())
 	}
 }
+
+func TestForInNode(t *testing.T) {
+	// Create tokens
+	forToken := token.Token{Type: token.FOR, Literal: "for"}
+	identToken := token.Token{Type: token.IDENT, Literal: "x"}
+	
+	// Create AST nodes
+	variable := NewIdent(identToken)
+	iterable := NewIdent(token.Token{Type: token.IDENT, Literal: "items"})
+	block := &Block{
+		token: token.Token{Type: token.LBRACE, Literal: "{"},
+		statements: []Node{
+			NewIdent(token.Token{Type: token.IDENT, Literal: "print"}),
+		},
+	}
+	
+	// Create ForIn node
+	forIn := NewForIn(forToken, variable, iterable, block)
+	
+	// Test all methods
+	if forIn.Token().Type != token.FOR {
+		t.Errorf("forIn.Token().Type wrong. got=%s", forIn.Token().Type)
+	}
+	
+	if forIn.Literal() != "for" {
+		t.Errorf("forIn.Literal() wrong. got=%s", forIn.Literal())
+	}
+	
+	if forIn.IsExpression() != false {
+		t.Errorf("forIn.IsExpression() wrong. got=%t", forIn.IsExpression())
+	}
+	
+	if forIn.Variable().Literal() != "x" {
+		t.Errorf("forIn.Variable().Literal() wrong. got=%s", forIn.Variable().Literal())
+	}
+	
+	if forIn.Iterable().String() != "items" {
+		t.Errorf("forIn.Iterable().String() wrong. got=%s", forIn.Iterable().String())
+	}
+	
+	if forIn.Consequence() == nil {
+		t.Error("forIn.Consequence() should not be nil")
+	}
+	
+	expected := "for x in items print"
+	if forIn.String() != expected {
+		t.Errorf("forIn.String() wrong. got=%q, expected=%q", forIn.String(), expected)
+	}
+}
+
+func TestForInNodeComplexCase(t *testing.T) {
+	// Test with more complex expressions
+	forToken := token.Token{Type: token.FOR, Literal: "for"}
+	
+	// Variable
+	variable := NewIdent(token.Token{Type: token.IDENT, Literal: "item"})
+	
+	// Complex iterable (list literal)
+	list := &List{
+		token: token.Token{Type: token.LBRACKET, Literal: "["},
+		items: []Expression{
+			&Int{token: token.Token{Type: token.INT, Literal: "1"}, value: 1},
+			&Int{token: token.Token{Type: token.INT, Literal: "2"}, value: 2},
+			&Int{token: token.Token{Type: token.INT, Literal: "3"}, value: 3},
+		},
+	}
+	
+	// Block with multiple statements
+	block := &Block{
+		token: token.Token{Type: token.LBRACE, Literal: "{"},
+		statements: []Node{
+			&Call{
+				token: token.Token{Type: token.IDENT, Literal: "print"},
+				function: NewIdent(token.Token{Type: token.IDENT, Literal: "print"}),
+				arguments: []Node{
+					NewIdent(token.Token{Type: token.IDENT, Literal: "item"}),
+				},
+			},
+		},
+	}
+	
+	forIn := NewForIn(forToken, variable, list, block)
+	
+	// Test String output
+	result := forIn.String()
+	if !contains(result, "for item in") {
+		t.Errorf("forIn.String() should contain 'for item in', got=%q", result)
+	}
+	if !contains(result, "[1, 2, 3]") {
+		t.Errorf("forIn.String() should contain array literal, got=%q", result)
+	}
+}
+
+func TestForInNodeMethods(t *testing.T) {
+	// Test that ForIn implements the Statement interface
+	forToken := token.Token{Type: token.FOR, Literal: "for"}
+	variable := NewIdent(token.Token{Type: token.IDENT, Literal: "x"})
+	iterable := NewIdent(token.Token{Type: token.IDENT, Literal: "items"})
+	block := &Block{token: token.Token{Type: token.LBRACE, Literal: "{"}}
+	
+	forIn := NewForIn(forToken, variable, iterable, block)
+	
+	// Test that it implements Node interface
+	var node Node = forIn
+	if node.Token().Type != token.FOR {
+		t.Errorf("ForIn should implement Node interface correctly")
+	}
+	
+	// Test StatementNode method (should not panic)
+	forIn.StatementNode()
+	
+	// Test that all accessors work
+	if forIn.Variable() != variable {
+		t.Errorf("Variable() should return the correct variable")
+	}
+	if forIn.Iterable() != iterable {
+		t.Errorf("Iterable() should return the correct iterable")
+	}
+	if forIn.Consequence() != block {
+		t.Errorf("Consequence() should return the correct block")
+	}
+}
+
+// Helper function for string containment check
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || 
+		(len(s) > len(substr) && 
+			(s[:len(substr)] == substr ||
+				s[len(s)-len(substr):] == substr ||
+				containsAt(s, substr))))
+}
+
+func containsAt(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/ast/statements.go
+++ b/ast/statements.go
@@ -394,7 +394,7 @@ func (f *ForIn) String() string {
 	out.WriteString(f.variable.String())
 	out.WriteString(" in ")
 	out.WriteString(f.iterable.String())
-	out.WriteString(": ")
+	out.WriteString(" ")
 	out.WriteString(f.consequence.String())
 	return out.String()
 }

--- a/ast/statements.go
+++ b/ast/statements.go
@@ -355,6 +355,50 @@ func (f *For) String() string {
 	return out.String()
 }
 
+// ForIn is a statement node that defines a Python-style for-in loop.
+type ForIn struct {
+	token token.Token
+
+	// variable is the identifier that holds the current iteration value
+	variable *Ident
+
+	// iterable is the expression that provides the values to iterate over
+	iterable Node
+
+	// consequence contains the statements that make up the loop body.
+	consequence *Block
+}
+
+// NewForIn creates a new ForIn node.
+func NewForIn(token token.Token, variable *Ident, iterable Node, consequence *Block) *ForIn {
+	return &ForIn{token: token, variable: variable, iterable: iterable, consequence: consequence}
+}
+
+func (f *ForIn) StatementNode() {}
+
+func (f *ForIn) IsExpression() bool { return false }
+
+func (f *ForIn) Token() token.Token { return f.token }
+
+func (f *ForIn) Literal() string { return f.token.Literal }
+
+func (f *ForIn) Variable() *Ident { return f.variable }
+
+func (f *ForIn) Iterable() Node { return f.iterable }
+
+func (f *ForIn) Consequence() *Block { return f.consequence }
+
+func (f *ForIn) String() string {
+	var out bytes.Buffer
+	out.WriteString("for ")
+	out.WriteString(f.variable.String())
+	out.WriteString(" in ")
+	out.WriteString(f.iterable.String())
+	out.WriteString(": ")
+	out.WriteString(f.consequence.String())
+	return out.String()
+}
+
 // Assign is a statement node used to describe a variable assignment.
 type Assign struct {
 	token    token.Token

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -233,6 +233,10 @@ func (c *Compiler) compile(node ast.Node) error {
 		if err := c.compileFor(node); err != nil {
 			return err
 		}
+	case *ast.ForIn:
+		if err := c.compileForIn(node); err != nil {
+			return err
+		}
 	case *ast.Control:
 		if err := c.compileControl(node); err != nil {
 			return err
@@ -1685,6 +1689,79 @@ func (c *Compiler) compileSimpleFor(node *ast.For) error {
 		delta := jumpBackPos - pos
 		if delta > math.MaxUint16 {
 			return fmt.Errorf("compile error: loop code size exceeded limits")
+		}
+		c.changeOperand(pos, uint16(delta))
+	}
+	return nil
+}
+
+func (c *Compiler) compileForIn(node *ast.ForIn) error {
+	// Compile the iterable expression
+	if err := c.compile(node.Iterable()); err != nil {
+		return err
+	}
+	// Get an iterator for the container at TOS
+	c.emit(op.GetIter)
+
+	code := c.current
+	code.symbols = code.symbols.NewBlock()
+	loop := c.startLoop()
+	loop.isRangeLoop = true
+	defer func() {
+		loop.end()
+		code.symbols = code.symbols.parent
+	}()
+
+	// ForIter instruction: pop iterator, advance it, push current values
+	// Use 3 to indicate Python-style single variable (gets value, not key)
+	iterPos := c.emit(op.ForIter, 0, 3) // 3 indicates Python-style single variable (gets value)
+
+	// Assign the current value of the iterator to the loop variable
+	varName := node.Variable().Literal()
+	sym, err := code.symbols.InsertVariable(varName)
+	if err != nil {
+		return err
+	}
+	if code.symbols.IsGlobal() {
+		c.emit(op.StoreGlobal, sym.Index())
+	} else {
+		c.emit(op.StoreFast, sym.Index())
+	}
+
+	// Compile the body of the loop
+	if err := c.compile(node.Consequence()); err != nil {
+		return err
+	}
+	c.emit(op.PopTop)
+
+	// Jump back to the start of the loop
+	delta, err := c.calculateDelta(iterPos)
+	if err != nil {
+		return err
+	}
+	jumpBackPos := c.emit(op.JumpBackward, delta)
+
+	// Update the ForIter instruction to jump "here" when done
+	delta, err = c.calculateDelta(iterPos)
+	if err != nil {
+		return err
+	}
+	c.changeOperand(iterPos, delta)
+
+	// Update breaks to jump to this point
+	for _, pos := range loop.breakPos {
+		delta, err = c.calculateDelta(pos)
+		if err != nil {
+			return err
+		}
+		c.changeOperand(pos, uint16(delta))
+	}
+
+	// Update continues
+	for _, pos := range loop.continuePos {
+		delta := jumpBackPos - pos
+		if delta > math.MaxUint16 {
+			return c.formatError("loop code size exceeded limits", node.Token().StartPosition)
 		}
 		c.changeOperand(pos, uint16(delta))
 	}

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -619,7 +619,7 @@ func TestForInWithBreakContinue(t *testing.T) {
 		x
 	}
 	`
-	
+
 	program, err := parser.Parse(context.Background(), input)
 	require.Nil(t, err)
 
@@ -646,7 +646,7 @@ func TestForInWithBreakContinue(t *testing.T) {
 			hasJumpBackward = true
 		}
 	}
-	
+
 	require.True(t, hasJumpForward, "Expected JumpForward instruction for break/continue")
 	require.True(t, hasJumpBackward, "Expected JumpBackward instruction for loop")
 }
@@ -659,7 +659,7 @@ func TestForInNestedLoops(t *testing.T) {
 		}
 	}
 	`
-	
+
 	program, err := parser.Parse(context.Background(), input)
 	require.Nil(t, err)
 
@@ -686,7 +686,7 @@ func TestForInNestedLoops(t *testing.T) {
 			getIterCount++
 		}
 	}
-	
+
 	require.Equal(t, 2, getIterCount, "Expected 2 GetIter instructions for nested loops")
 	require.Equal(t, 2, forIterCount, "Expected 2 ForIter instructions for nested loops")
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1082,24 +1082,24 @@ func (p *Parser) parseFor() ast.Node {
 		variable := ast.NewIdent(p.curToken)
 		p.nextToken() // Move to 'in'
 		p.nextToken() // Move past 'in'
-		
+
 		// Parse the iterable expression
 		iterable := p.parseExpression(LOWEST)
 		if iterable == nil {
 			p.setTokenError(p.curToken, "invalid iterable in for-in loop")
 			return nil
 		}
-		
+
 		// Expect opening brace directly (no colon)
 		if !p.expectPeek("for-in loop", token.LBRACE) {
 			return nil
 		}
-		
+
 		consequence := p.parseBlock()
 		if consequence == nil {
 			return nil
 		}
-		
+
 		return ast.NewForIn(forToken, variable, iterable, consequence)
 	}
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1076,6 +1076,38 @@ func (p *Parser) parseFor() ast.Node {
 		return ast.NewSimpleFor(forToken, consequence)
 	}
 
+	// Check for Python-style "for x in iterable:" form
+	if p.curTokenIs(token.IDENT) && p.peekTokenIs(token.IN) {
+		// Parse variable identifier
+		variable := ast.NewIdent(p.curToken)
+		p.nextToken() // Move to 'in'
+		p.nextToken() // Move past 'in'
+		
+		// Parse the iterable expression
+		iterable := p.parseExpression(LOWEST)
+		if iterable == nil {
+			p.setTokenError(p.curToken, "invalid iterable in for-in loop")
+			return nil
+		}
+		
+		// Expect colon
+		if !p.expectPeek("for-in loop", token.COLON) {
+			return nil
+		}
+		
+		// For Python-style syntax, we expect a block after the colon
+		if !p.expectPeek("for-in loop", token.LBRACE) {
+			return nil
+		}
+		
+		consequence := p.parseBlock()
+		if consequence == nil {
+			return nil
+		}
+		
+		return ast.NewForIn(forToken, variable, iterable, consequence)
+	}
+
 	// Parse the initialization or condition
 	var init, condition, post ast.Node
 	if !p.curTokenIs(token.SEMICOLON) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1076,7 +1076,7 @@ func (p *Parser) parseFor() ast.Node {
 		return ast.NewSimpleFor(forToken, consequence)
 	}
 
-	// Check for Python-style "for x in iterable:" form
+	// Check for Python-style "for x in iterable" form
 	if p.curTokenIs(token.IDENT) && p.peekTokenIs(token.IN) {
 		// Parse variable identifier
 		variable := ast.NewIdent(p.curToken)
@@ -1090,12 +1090,7 @@ func (p *Parser) parseFor() ast.Node {
 			return nil
 		}
 		
-		// Expect colon
-		if !p.expectPeek("for-in loop", token.COLON) {
-			return nil
-		}
-		
-		// For Python-style syntax, we expect a block after the colon
+		// Expect opening brace directly (no colon)
 		if !p.expectPeek("for-in loop", token.LBRACE) {
 			return nil
 		}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1224,3 +1224,36 @@ func TestBitwiseAnd(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, "(1 & 2)", result.String())
 }
+
+func TestForInLoop(t *testing.T) {
+	tests := []struct {
+		input    string
+		variable string
+		iterable string
+	}{
+		{
+			"for x in [1, 2, 3]: { }",
+			"x",
+			"[1, 2, 3]",
+		},
+		{
+			"for item in items: { print(item) }",
+			"item",
+			"items",
+		},
+		{
+			"for fruit in fruits: { print(fruit) }",
+			"fruit",
+			"fruits",
+		},
+	}
+	for _, tt := range tests {
+		program, err := Parse(context.Background(), tt.input)
+		require.Nil(t, err)
+		require.Len(t, program.Statements(), 1)
+		expr, ok := program.First().(*ast.ForIn)
+		require.True(t, ok)
+		require.Equal(t, tt.variable, expr.Variable().String())
+		require.Equal(t, tt.iterable, expr.Iterable().String())
+	}
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -799,7 +799,7 @@ func TestForInLoopErrors(t *testing.T) {
 			expectedErr: "unexpected end of file",
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := Parse(context.Background(), tt.input)
@@ -814,10 +814,10 @@ func TestForInLoopAST(t *testing.T) {
 	program, err := Parse(context.Background(), input)
 	require.Nil(t, err)
 	require.Len(t, program.Statements(), 1)
-	
+
 	forIn, ok := program.First().(*ast.ForIn)
 	require.True(t, ok)
-	
+
 	// Test all AST node methods
 	require.Equal(t, "for", forIn.Literal())
 	require.Equal(t, "FOR", string(forIn.Token().Type))
@@ -825,7 +825,7 @@ func TestForInLoopAST(t *testing.T) {
 	require.Equal(t, "item", forIn.Variable().Literal())
 	require.Equal(t, "collection", forIn.Iterable().String())
 	require.NotNil(t, forIn.Consequence())
-	
+
 	// Test String() method
 	expected := "for item in collection print(item)"
 	require.Equal(t, expected, forIn.String())
@@ -838,7 +838,6 @@ func TestForInLoopEdgeCases(t *testing.T) {
 		variable string
 		iterable string
 	}{
-
 		{
 			name:     "nested array access",
 			input:    "for val in arr[0] { }",
@@ -858,7 +857,7 @@ func TestForInLoopEdgeCases(t *testing.T) {
 			iterable: "(obj.method().field[0])",
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			program, err := Parse(context.Background(), tt.input)
@@ -890,7 +889,7 @@ func TestForInLoopParseErrorCases(t *testing.T) {
 			input: "for x in items",
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := Parse(context.Background(), tt.input)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1232,17 +1232,17 @@ func TestForInLoop(t *testing.T) {
 		iterable string
 	}{
 		{
-			"for x in [1, 2, 3]: { }",
+			"for x in [1, 2, 3] { }",
 			"x",
 			"[1, 2, 3]",
 		},
 		{
-			"for item in items: { print(item) }",
+			"for item in items { print(item) }",
 			"item",
 			"items",
 		},
 		{
-			"for fruit in fruits: { print(fruit) }",
+			"for fruit in fruits { print(fruit) }",
 			"fruit",
 			"fruits",
 		},

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -680,6 +680,9 @@ func (vm *VirtualMachine) eval(ctx context.Context) error {
 				} else if nameCount == 2 {
 					vm.push(obj.Value())
 					vm.push(obj.Key())
+				} else if nameCount == 3 {
+					// Python-style for-in: single variable gets the value
+					vm.push(obj.Value())
 				} else if nameCount != 0 {
 					return errz.EvalErrorf("eval error: invalid iteration")
 				}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -3159,7 +3159,7 @@ func TestNewEmptyClone(t *testing.T) {
 func TestForIn1(t *testing.T) {
 	result, err := run(context.Background(), `
 	sum := 0
-	for x in [1, 2, 3]: {
+	for x in [1, 2, 3] {
 		sum = sum + x
 	}
 	sum
@@ -3172,7 +3172,7 @@ func TestForIn2(t *testing.T) {
 	result, err := run(context.Background(), `
 	fruits := ["apple", "banana", "cherry"]
 	last := ""
-	for fruit in fruits: {
+	for fruit in fruits {
 		last = fruit
 	}
 	last
@@ -3184,7 +3184,7 @@ func TestForIn2(t *testing.T) {
 func TestForIn3(t *testing.T) {
 	result, err := run(context.Background(), `
 	items := []
-	for x in [10, 20, 30]: {
+	for x in [10, 20, 30] {
 		items.append(x * 2)
 	}
 	items
@@ -3200,7 +3200,7 @@ func TestForIn3(t *testing.T) {
 func TestForInString(t *testing.T) {
 	result, err := run(context.Background(), `
 	chars := []
-	for c in "hello": {
+	for c in "hello" {
 		chars.append(c)
 	}
 	chars
@@ -3218,7 +3218,7 @@ func TestForInString(t *testing.T) {
 func TestForInBreakContinue(t *testing.T) {
 	result, err := run(context.Background(), `
 	sum := 0
-	for x in [1, 2, 3, 4, 5]: {
+	for x in [1, 2, 3, 4, 5] {
 		if x == 3 {
 			continue
 		}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -3411,9 +3411,9 @@ func TestForInWithDifferentTypes(t *testing.T) {
 			result
 			`,
 			expected: object.NewList([]object.Object{
-				object.NewString("a"),  // string character
-				object.NewString("b"),  // string character
-				object.NewString("c"),  // string character
+				object.NewString("a"), // string character
+				object.NewString("b"), // string character
+				object.NewString("c"), // string character
 			}),
 		},
 	}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -3155,3 +3155,80 @@ func TestNewEmptyClone(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, intResult.Value(), int64(200))
 }
+
+func TestForIn1(t *testing.T) {
+	result, err := run(context.Background(), `
+	sum := 0
+	for x in [1, 2, 3]: {
+		sum = sum + x
+	}
+	sum
+	`)
+	require.Nil(t, err)
+	require.Equal(t, object.NewInt(6), result)
+}
+
+func TestForIn2(t *testing.T) {
+	result, err := run(context.Background(), `
+	fruits := ["apple", "banana", "cherry"]
+	last := ""
+	for fruit in fruits: {
+		last = fruit
+	}
+	last
+	`)
+	require.Nil(t, err)
+	require.Equal(t, object.NewString("cherry"), result)
+}
+
+func TestForIn3(t *testing.T) {
+	result, err := run(context.Background(), `
+	items := []
+	for x in [10, 20, 30]: {
+		items.append(x * 2)
+	}
+	items
+	`)
+	require.Nil(t, err)
+	require.Equal(t, object.NewList([]object.Object{
+		object.NewInt(20),
+		object.NewInt(40),
+		object.NewInt(60),
+	}), result)
+}
+
+func TestForInString(t *testing.T) {
+	result, err := run(context.Background(), `
+	chars := []
+	for c in "hello": {
+		chars.append(c)
+	}
+	chars
+	`)
+	require.Nil(t, err)
+	require.Equal(t, object.NewList([]object.Object{
+		object.NewString("h"),
+		object.NewString("e"),
+		object.NewString("l"),
+		object.NewString("l"),
+		object.NewString("o"),
+	}), result)
+}
+
+func TestForInBreakContinue(t *testing.T) {
+	result, err := run(context.Background(), `
+	sum := 0
+	for x in [1, 2, 3, 4, 5]: {
+		if x == 3 {
+			continue
+		}
+		if x == 5 {
+			break
+		}
+		sum = sum + x
+	}
+	sum
+	`)
+	require.Nil(t, err)
+	require.Equal(t, object.NewInt(7), result) // 1 + 2 + 4, skipping 3 and breaking before 5
+}


### PR DESCRIPTION
Add support for Python-style `for x in iterable:` loops to Risor to enhance expressiveness and user-friendliness.

---
<a href="https://cursor.com/background-agent?bcId=bc-4bb217c7-8155-4e78-bc47-9dca7a891060">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4bb217c7-8155-4e78-bc47-9dca7a891060">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>